### PR TITLE
feat: import historical GPX tracks into the parquet store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-parquet",
-  "version": "0.7.20-beta.3",
+  "version": "0.7.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-parquet",
-      "version": "0.7.20-beta.3",
+      "version": "0.7.30",
       "cpu": [
         "x64",
         "arm64",
@@ -29,11 +29,13 @@
         "fs-extra": "^11.2.0",
         "glob": "^11.0.0",
         "minimatch": "^9.0.0",
+        "multer": "^2.0.0",
         "ws": "^8.18.3"
       },
       "devDependencies": {
         "@types/express": "^4.17.0",
         "@types/fs-extra": "^11.0.0",
+        "@types/multer": "^2.0.0",
         "@types/node": "^20.0.0",
         "@types/ws": "^8.18.1",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -2126,6 +2128,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz",
+      "integrity": "sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.19.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.8.tgz",
@@ -2682,6 +2694,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3002,6 +3020,12 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
     "node_modules/builtin-modules": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
@@ -3025,6 +3049,17 @@
       "peer": true,
       "dependencies": {
         "semver": "^7.0.0"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -3152,6 +3187,35 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -5711,6 +5775,25 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -6734,6 +6817,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -7188,6 +7279,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -7255,6 +7352,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utilium": {
       "version": "1.10.1",

--- a/package.json
+++ b/package.json
@@ -66,11 +66,13 @@
     "fs-extra": "^11.2.0",
     "glob": "^11.0.0",
     "minimatch": "^9.0.0",
+    "multer": "^2.0.0",
     "ws": "^8.18.3"
   },
   "devDependencies": {
     "@types/express": "^4.17.0",
     "@types/fs-extra": "^11.0.0",
+    "@types/multer": "^2.0.0",
     "@types/node": "^20.0.0",
     "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^6.21.0",

--- a/public/index.html
+++ b/public/index.html
@@ -3800,6 +3800,272 @@
                 ></div>
               </div>
             </div>
+
+            <!-- GPX Import Section -->
+            <div
+              id="gpxImportPanel"
+              style="
+                margin-top: 30px;
+                padding: 20px;
+                background: #f3e5f5;
+                border-radius: 8px;
+                border: 2px solid #8e24aa;
+              "
+            >
+              <h3 style="margin-top: 0; color: #4a148c">
+                📥 Import GPX Files
+              </h3>
+              <p style="color: #666; margin-bottom: 15px">
+                Import historical GPS tracks from .gpx files into the parquet
+                store. Each track point is expanded into SignalK records for
+                the selected paths and written as raw-tier parquet files.
+              </p>
+
+              <div class="form-group">
+                <label for="gpxFileInput">GPX files to import</label>
+                <div
+                  id="gpxDropZone"
+                  role="button"
+                  tabindex="0"
+                  aria-label="Click to pick .gpx files or drop them here"
+                  style="
+                    border: 2px dashed #8e24aa;
+                    border-radius: 6px;
+                    padding: 25px;
+                    text-align: center;
+                    background: #fafafa;
+                    cursor: pointer;
+                    transition: background 0.15s, border-color 0.15s;
+                  "
+                >
+                  <div style="color: #6a1b9a; font-size: 1.05em">
+                    <strong>Click to pick files</strong> or drag &amp; drop
+                    .gpx files here
+                  </div>
+                  <div
+                    id="gpxSelectedFiles"
+                    style="
+                      margin-top: 12px;
+                      color: #666;
+                      font-size: 0.9em;
+                      text-align: left;
+                    "
+                  >
+                    No files selected
+                  </div>
+                </div>
+                <input
+                  type="file"
+                  id="gpxFileInput"
+                  accept=".gpx,application/gpx+xml"
+                  multiple
+                  style="display: none"
+                />
+                <div
+                  id="gpxRejectedNote"
+                  style="
+                    margin-top: 6px;
+                    color: #c62828;
+                    font-size: 0.85em;
+                    display: none;
+                  "
+                ></div>
+              </div>
+
+              <details id="gpxAdvancedBlock" style="margin-bottom: 15px">
+                <summary
+                  style="cursor: pointer; color: #6a1b9a; font-weight: 500"
+                >
+                  Advanced: import from a server-side directory instead
+                </summary>
+                <div class="form-group" style="margin-top: 10px">
+                  <label for="gpxSourceDirectory"
+                    >Server directory (searched recursively)</label
+                  >
+                  <input
+                    type="text"
+                    id="gpxSourceDirectory"
+                    placeholder="/home/pi/tracks"
+                    style="width: 100%"
+                  />
+                  <small style="color: #666">
+                    Path is evaluated on the Signal K host — useful for bulk
+                    imports from mounted USB drives.
+                  </small>
+                </div>
+                <div
+                  class="form-group"
+                  style="display: flex; align-items: center; gap: 10px; margin-top: 10px"
+                >
+                  <input
+                    type="checkbox"
+                    id="gpxDeleteSource"
+                    style="width: auto"
+                  />
+                  <label
+                    for="gpxDeleteSource"
+                    style="margin: 0; font-weight: normal"
+                    >Delete source .gpx files from the server after successful
+                    import</label
+                  >
+                </div>
+                <div style="margin-top: 10px">
+                  <button
+                    onclick="scanGpxImport()"
+                    style="background: #8e24aa"
+                  >
+                    🔍 Scan Files
+                  </button>
+                </div>
+              </details>
+
+              <div class="form-group">
+                <label for="gpxContext">Target vessel</label>
+                <input
+                  type="text"
+                  id="gpxContext"
+                  placeholder="(default: this vessel)"
+                  style="width: 100%"
+                />
+                <small style="color: #666"
+                  >Leave blank to import for this vessel. Only change this if
+                  the data belongs to another vessel already known to Signal K
+                  (advanced).</small
+                >
+              </div>
+
+              <div class="form-group">
+                <label>Paths to emit per track point</label>
+                <div style="display: flex; flex-direction: column; gap: 5px">
+                  <label style="font-weight: normal">
+                    <input
+                      type="checkbox"
+                      class="gpxPath"
+                      value="navigation.position"
+                      checked
+                    />
+                    navigation.position
+                  </label>
+                  <label style="font-weight: normal">
+                    <input
+                      type="checkbox"
+                      class="gpxPath"
+                      value="navigation.speedOverGround"
+                      checked
+                    />
+                    navigation.speedOverGround
+                  </label>
+                  <label style="font-weight: normal">
+                    <input
+                      type="checkbox"
+                      class="gpxPath"
+                      value="navigation.courseOverGroundTrue"
+                      checked
+                    />
+                    navigation.courseOverGroundTrue
+                  </label>
+                  <label style="font-weight: normal">
+                    <input
+                      type="checkbox"
+                      class="gpxPath"
+                      value="navigation.gnss.antennaAltitude"
+                      checked
+                    />
+                    navigation.gnss.antennaAltitude
+                  </label>
+                </div>
+                <small style="color: #666; display: block; margin-top: 6px">
+                  Values are stored in SignalK's canonical units (m/s, rad, m).
+                  Tools that read the parquet files will display them in your
+                  configured display units, just like live data.
+                </small>
+              </div>
+
+              <div
+                style="
+                  margin-top: 20px;
+                  display: flex;
+                  gap: 10px;
+                  flex-wrap: wrap;
+                "
+              >
+                <button
+                  onclick="startGpxImport()"
+                  style="background: #4caf50"
+                  id="startGpxImportBtn"
+                  disabled
+                >
+                  ▶️ Start Import
+                </button>
+                <button
+                  onclick="cancelGpxImport()"
+                  style="background: #f44336"
+                  id="cancelGpxImportBtn"
+                  disabled
+                >
+                  ❌ Cancel
+                </button>
+              </div>
+
+              <div
+                id="gpxScanResults"
+                style="
+                  margin-top: 20px;
+                  display: none;
+                  padding: 15px;
+                  background: white;
+                  border-radius: 5px;
+                  border: 1px solid #ddd;
+                "
+              >
+                <h4 style="margin-top: 0">Scan Results</h4>
+                <div id="gpxScanContent"></div>
+              </div>
+
+              <div
+                id="gpxImportProgress"
+                style="
+                  margin-top: 20px;
+                  display: none;
+                  padding: 15px;
+                  background: white;
+                  border-radius: 5px;
+                  border: 1px solid #ddd;
+                "
+              >
+                <h4 style="margin-top: 0">Import Progress</h4>
+                <div
+                  style="
+                    background: #e0e0e0;
+                    border-radius: 5px;
+                    height: 20px;
+                    overflow: hidden;
+                    margin-bottom: 10px;
+                  "
+                >
+                  <div
+                    id="gpxImportProgressBar"
+                    style="
+                      background: linear-gradient(90deg, #8e24aa, #ba68c8);
+                      height: 100%;
+                      width: 0%;
+                      transition: width 0.3s;
+                    "
+                  ></div>
+                </div>
+                <div id="gpxImportProgressText" aria-live="polite">
+                  0% complete
+                </div>
+                <div
+                  id="gpxImportCurrentFile"
+                  style="color: #666; font-size: 0.9em; margin-top: 5px"
+                ></div>
+                <div
+                  id="gpxImportStats"
+                  style="color: #666; font-size: 0.9em; margin-top: 5px"
+                ></div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -3807,6 +4073,7 @@
 
     <script type="module" src="js/main.js"></script>
     <script src="js/migration.js"></script>
+    <script src="js/import.js"></script>
 
     <!-- Analysis History Modal -->
     <div

--- a/public/js/import.js
+++ b/public/js/import.js
@@ -1,0 +1,522 @@
+/**
+ * GPX Import UI
+ *
+ * Primary flow: user picks (or drops) local .gpx files and clicks Start Import.
+ * Files are posted multipart to /api/import/gpx/upload; the backend stages
+ * them and kicks off the existing import job pipeline.
+ *
+ * Advanced flow: user enters a server-side directory path. This is useful
+ * for bulk imports from mounted USB drives or existing track archives on
+ * the Signal K host.
+ */
+
+let currentGpxImportJobId = localStorage.getItem('gpxImportJobId') || null;
+let gpxImportPollInterval = null;
+let gpxSelectedFiles = [];
+let gpxUploadInFlight = false;
+
+// Human labels for the backend "phase" field — the service uses internal
+// short names, but users shouldn't see "parse" or "write" bare.
+const GPX_PHASE_LABEL = {
+  scan: 'Finding files',
+  parse: 'Reading files',
+  write: 'Writing parquet',
+};
+
+function getSelectedGpxPaths() {
+  return Array.from(document.querySelectorAll('.gpxPath'))
+    .filter(cb => cb.checked)
+    .map(cb => cb.value);
+}
+
+function formatBytes(bytes) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
+}
+
+function renderSelectedFiles() {
+  const el = document.getElementById('gpxSelectedFiles');
+  if (!el) return;
+  // Use textContent/DOM API instead of innerHTML so filenames from the user's
+  // disk can't smuggle HTML into the page.
+  el.textContent = '';
+  if (gpxSelectedFiles.length === 0) {
+    el.textContent = 'No files selected';
+    return;
+  }
+  const total = gpxSelectedFiles.reduce((sum, f) => sum + f.size, 0);
+  const header = document.createElement('strong');
+  header.textContent = `${gpxSelectedFiles.length} file(s), ${formatBytes(total)}`;
+  el.appendChild(header);
+  const shown = Math.min(10, gpxSelectedFiles.length);
+  for (let i = 0; i < shown; i++) {
+    const f = gpxSelectedFiles[i];
+    const row = document.createElement('div');
+    row.textContent = `• ${f.name} (${formatBytes(f.size)})`;
+    el.appendChild(row);
+  }
+  if (gpxSelectedFiles.length > shown) {
+    const more = document.createElement('div');
+    more.style.color = '#999';
+    more.style.marginTop = '4px';
+    more.textContent = `…and ${gpxSelectedFiles.length - shown} more`;
+    el.appendChild(more);
+  }
+}
+
+function refreshStartButtonState() {
+  const btn = document.getElementById('startGpxImportBtn');
+  if (!btn) return;
+  btn.disabled =
+    gpxUploadInFlight ||
+    currentGpxImportJobId !== null ||
+    (gpxSelectedFiles.length === 0 && !serverDirValue());
+}
+
+function setGpxFiles(fileList) {
+  const all = Array.from(fileList);
+  const accepted = all.filter(f => f.name.toLowerCase().endsWith('.gpx'));
+  const rejected = all.length - accepted.length;
+  gpxSelectedFiles = accepted;
+
+  // Surface a clear note when the user dropped non-.gpx files (or a folder,
+  // which appears as zero files in dataTransfer.files).
+  const note = document.getElementById('gpxRejectedNote');
+  if (note) {
+    if (all.length === 0) {
+      note.textContent =
+        'Nothing to import — folders can’t be dragged in, please pick .gpx files directly.';
+      note.style.display = 'block';
+    } else if (rejected > 0) {
+      note.textContent = `Ignored ${rejected} non-.gpx file(s).`;
+      note.style.display = 'block';
+    } else {
+      note.style.display = 'none';
+    }
+  }
+
+  renderSelectedFiles();
+  refreshStartButtonState();
+}
+
+function serverDirValue() {
+  const el = document.getElementById('gpxSourceDirectory');
+  return el ? el.value.trim() : '';
+}
+
+function initGpxDropZone() {
+  const zone = document.getElementById('gpxDropZone');
+  const input = document.getElementById('gpxFileInput');
+  if (!zone || !input) return;
+
+  const openPicker = () => input.click();
+  zone.addEventListener('click', openPicker);
+  // Keyboard activation (Enter / Space) for screen-reader and keyboard users;
+  // the zone carries role="button" + tabindex="0" in the HTML for this.
+  zone.addEventListener('keydown', e => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      openPicker();
+    }
+  });
+  input.addEventListener('change', () => setGpxFiles(input.files));
+
+  zone.addEventListener('dragover', e => {
+    e.preventDefault();
+    zone.style.background = '#f3e5f5';
+    zone.style.borderColor = '#6a1b9a';
+  });
+  zone.addEventListener('dragleave', () => {
+    zone.style.background = '#fafafa';
+    zone.style.borderColor = '#8e24aa';
+  });
+  zone.addEventListener('drop', e => {
+    e.preventDefault();
+    zone.style.background = '#fafafa';
+    zone.style.borderColor = '#8e24aa';
+    if (e.dataTransfer && e.dataTransfer.files) {
+      setGpxFiles(e.dataTransfer.files);
+    }
+  });
+
+  // Also enable Start Import when the user types a server dir instead.
+  const dirInput = document.getElementById('gpxSourceDirectory');
+  if (dirInput) {
+    dirInput.addEventListener('input', refreshStartButtonState);
+  }
+}
+
+// Warn the user if they try to close the tab during an upload — the browser
+// will abort the multipart request and leave temp files behind on the server.
+window.addEventListener('beforeunload', e => {
+  if (gpxUploadInFlight) {
+    e.preventDefault();
+    e.returnValue = '';
+  }
+});
+
+// Map a failed fetch response into a user-friendly error string. 401 from
+// SignalK means the browser has no session cookie — surface a clear hint
+// instead of the generic "Failed to start import" with a cryptic message.
+async function explainHttpError(response) {
+  if (response.status === 401) {
+    return 'Not logged in. Open the Signal K admin UI, log in, then try again from this tab.';
+  }
+  if (response.status === 413) {
+    return 'Upload too large (over 200 MB per file or 500 files total).';
+  }
+  try {
+    const d = await response.json();
+    if (d && d.error) return d.error;
+  } catch {
+    // not JSON (e.g. HTML login page)
+  }
+  return `HTTP ${response.status} ${response.statusText || ''}`.trim();
+}
+
+async function scanGpxImport() {
+  // Only meaningful for the server-directory fallback.
+  const sourceDir = serverDirValue();
+  const resultsDiv = document.getElementById('gpxScanResults');
+  const contentDiv = document.getElementById('gpxScanContent');
+
+  if (!sourceDir) {
+    alert(
+      'Enter a server directory first (Advanced). For uploads, just click Start Import.'
+    );
+    return;
+  }
+
+  resultsDiv.style.display = 'block';
+  contentDiv.innerHTML = '<p><span class="loading">Scanning files...</span></p>';
+
+  try {
+    const response = await fetch(
+      '/plugins/signalk-parquet/api/import/gpx/scan',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sourceDirectory: sourceDir }),
+      }
+    );
+    if (!response.ok) {
+      contentDiv.textContent = `Scan failed: ${await explainHttpError(response)}`;
+      return;
+    }
+    const data = await response.json();
+
+    if (!data.success) {
+      contentDiv.textContent = `Scan failed: ${data.error}`;
+      return;
+    }
+
+    if (data.totalFiles === 0) {
+      contentDiv.innerHTML =
+        '<p style="color: #666;">No .gpx files found under that directory.</p>';
+      return;
+    }
+
+    // Render file list as DOM (not innerHTML) so user-supplied filenames
+    // can't inject markup.
+    const tbody = document.createElement('tbody');
+    for (const f of data.files.slice(0, 200)) {
+      const tr = document.createElement('tr');
+      const tdName = document.createElement('td');
+      tdName.style.fontFamily = 'monospace';
+      tdName.style.fontSize = '0.9em';
+      tdName.textContent = f.name;
+      const tdSize = document.createElement('td');
+      tdSize.style.textAlign = 'right';
+      tdSize.textContent = `${f.sizeMB} MB`;
+      tr.appendChild(tdName);
+      tr.appendChild(tdSize);
+      tbody.appendChild(tr);
+    }
+
+    contentDiv.innerHTML = `
+      <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; margin-bottom: 15px;">
+        <div style="background: #f3e5f5; padding: 10px; border-radius: 5px; text-align: center;">
+          <strong>GPX Files Found</strong><br>
+          <span style="font-size: 1.3em;">${data.totalFiles.toLocaleString()}</span>
+        </div>
+        <div style="background: #e1bee7; padding: 10px; border-radius: 5px; text-align: center;">
+          <strong>Total Size</strong><br>
+          <span style="font-size: 1.3em;">${data.totalSizeMB} MB</span>
+        </div>
+      </div>
+      <details>
+        <summary style="cursor: pointer; color: #6a1b9a; font-weight: 500;">File list</summary>
+        <table style="width: 100%; border-collapse: collapse; margin-top: 10px; font-size: 0.9em;">
+          <thead>
+            <tr style="background: #f5f5f5;">
+              <th style="text-align: left; padding: 8px; border-bottom: 2px solid #ddd;">File</th>
+              <th style="text-align: right; padding: 8px; border-bottom: 2px solid #ddd;">Size</th>
+            </tr>
+          </thead>
+        </table>
+      </details>
+    `;
+    // Insert the safely-built tbody into the table we just rendered.
+    const table = contentDiv.querySelector('table');
+    if (table) table.appendChild(tbody);
+    if (data.files.length > 200) {
+      const overflow = document.createElement('p');
+      overflow.style.color = '#666';
+      overflow.style.marginTop = '10px';
+      overflow.textContent = `Showing 200 of ${data.files.length} files`;
+      contentDiv.appendChild(overflow);
+    }
+  } catch (error) {
+    contentDiv.textContent = `Scan failed: ${error.message}`;
+  }
+}
+
+async function startGpxImport() {
+  const startBtn = document.getElementById('startGpxImportBtn');
+  const cancelBtn = document.getElementById('cancelGpxImportBtn');
+  const progressDiv = document.getElementById('gpxImportProgress');
+  const progressText = document.getElementById('gpxImportProgressText');
+  const progressBar = document.getElementById('gpxImportProgressBar');
+  const currentFileEl = document.getElementById('gpxImportCurrentFile');
+
+  // Disable the button immediately so a second click can't race us before
+  // validation alerts fire and before we flip gpxUploadInFlight.
+  startBtn.disabled = true;
+
+  const sourceDir = serverDirValue();
+  const contextInput = document.getElementById('gpxContext').value.trim();
+  const paths = getSelectedGpxPaths();
+  const deleteSource = !!document.getElementById('gpxDeleteSource')?.checked;
+
+  if (gpxSelectedFiles.length === 0 && !sourceDir) {
+    alert(
+      'Pick at least one .gpx file, or set a server directory under Advanced.'
+    );
+    refreshStartButtonState();
+    return;
+  }
+  if (paths.length === 0) {
+    alert('Please select at least one Signal K path to emit.');
+    refreshStartButtonState();
+    return;
+  }
+
+  // Kick off the UI transition before the request so the user gets immediate
+  // feedback even when the multipart body takes a while to send.
+  progressDiv.style.display = 'block';
+  progressBar.style.width = '0%';
+  progressBar.style.background = 'linear-gradient(90deg, #8e24aa, #ba68c8)';
+  if (gpxSelectedFiles.length > 0) {
+    const total = gpxSelectedFiles.reduce((s, f) => s + f.size, 0);
+    progressText.textContent = `Uploading ${gpxSelectedFiles.length} file(s), ${formatBytes(total)}…`;
+  } else {
+    progressText.textContent = 'Starting…';
+  }
+  if (currentFileEl) currentFileEl.textContent = '';
+  cancelBtn.disabled = false;
+
+  try {
+    let response;
+    gpxUploadInFlight = true;
+    if (gpxSelectedFiles.length > 0) {
+      const form = new FormData();
+      for (const f of gpxSelectedFiles) {
+        form.append('files', f, f.name);
+      }
+      if (contextInput) form.append('context', contextInput);
+      form.append('paths', paths.join(','));
+      response = await fetch(
+        '/plugins/signalk-parquet/api/import/gpx/upload',
+        { method: 'POST', body: form }
+      );
+    } else {
+      response = await fetch('/plugins/signalk-parquet/api/import/gpx', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sourceDirectory: sourceDir,
+          context: contextInput || undefined,
+          paths,
+          deleteSource,
+        }),
+      });
+    }
+    gpxUploadInFlight = false;
+
+    if (!response.ok) {
+      alert(`Failed to start import: ${await explainHttpError(response)}`);
+      progressDiv.style.display = 'none';
+      cancelBtn.disabled = true;
+      refreshStartButtonState();
+      return;
+    }
+
+    const data = await response.json();
+    if (!data.success) {
+      alert(`Failed to start import: ${data.error}`);
+      progressDiv.style.display = 'none';
+      cancelBtn.disabled = true;
+      refreshStartButtonState();
+      return;
+    }
+
+    currentGpxImportJobId = data.jobId;
+    localStorage.setItem('gpxImportJobId', data.jobId);
+    gpxImportPollInterval = setInterval(pollGpxImportProgress, 1000);
+  } catch (error) {
+    gpxUploadInFlight = false;
+    alert(`Failed to start import: ${error.message}`);
+    progressDiv.style.display = 'none';
+    cancelBtn.disabled = true;
+    refreshStartButtonState();
+  }
+}
+
+async function pollGpxImportProgress() {
+  if (!currentGpxImportJobId) return;
+
+  try {
+    const response = await fetch(
+      `/plugins/signalk-parquet/api/import/gpx/progress/${currentGpxImportJobId}`
+    );
+
+    // 404 = job TTL-evicted. Stop polling silently.
+    if (response.status === 404) {
+      clearInterval(gpxImportPollInterval);
+      gpxImportPollInterval = null;
+      currentGpxImportJobId = null;
+      localStorage.removeItem('gpxImportJobId');
+      document.getElementById('gpxImportProgress').style.display = 'none';
+      document.getElementById('cancelGpxImportBtn').disabled = true;
+      refreshStartButtonState();
+      return;
+    }
+    if (!response.ok) {
+      // transient error — don't kill the poll loop over one bad response
+      return;
+    }
+
+    const data = await response.json();
+    updateGpxImportProgress(data);
+
+    if (
+      data.status === 'completed' ||
+      data.status === 'cancelled' ||
+      data.status === 'error'
+    ) {
+      clearInterval(gpxImportPollInterval);
+      gpxImportPollInterval = null;
+      currentGpxImportJobId = null;
+      localStorage.removeItem('gpxImportJobId');
+      document.getElementById('cancelGpxImportBtn').disabled = true;
+
+      if (data.status === 'completed') {
+        const parquetCount = (data.filesCreated || []).length;
+        const hint = samplePartitionPath(data.filesCreated);
+        alert(
+          `Import complete.\n\n` +
+            `Files imported:   ${data.filesImported}\n` +
+            `Files skipped:    ${data.filesSkipped}\n` +
+            `Points parsed:    ${Number(data.pointsParsed).toLocaleString()}\n` +
+            `Records written:  ${Number(data.recordsWritten).toLocaleString()}\n` +
+            `Parquet files:    ${parquetCount}\n` +
+            (hint ? `\nFiles landed under:\n  ${hint}` : '')
+        );
+        gpxSelectedFiles = [];
+        renderSelectedFiles();
+        const note = document.getElementById('gpxRejectedNote');
+        if (note) note.style.display = 'none';
+      } else if (data.status === 'cancelled') {
+        alert('Import cancelled.');
+      } else if (data.status === 'error') {
+        alert(`Import failed: ${data.error}`);
+      }
+      refreshStartButtonState();
+    }
+  } catch (error) {
+    console.error('Error polling GPX import progress:', error);
+  }
+}
+
+// Extract the common "tier=raw/context=.../path=.../" prefix from the list
+// of parquet paths produced, so the completion dialog can tell the user
+// roughly where the data went without dumping 16 full paths.
+function samplePartitionPath(files) {
+  if (!Array.isArray(files) || files.length === 0) return '';
+  // Take the first file's path up through the last "year=" segment's parent.
+  const parts = files[0].split(/[\\/]/);
+  const yearIdx = parts.findIndex(p => p.startsWith('year='));
+  if (yearIdx <= 0) return files[0];
+  return parts.slice(0, yearIdx).join('/') + '/…';
+}
+
+function updateGpxImportProgress(data) {
+  const progressBar = document.getElementById('gpxImportProgressBar');
+  const progressText = document.getElementById('gpxImportProgressText');
+  const currentFile = document.getElementById('gpxImportCurrentFile');
+  const stats = document.getElementById('gpxImportStats');
+
+  const phase = GPX_PHASE_LABEL[data.phase] || data.phase || '';
+  progressBar.style.width = `${data.percent}%`;
+  progressText.textContent =
+    `${data.percent}% complete (${data.processed}/${data.total} files` +
+    (phase ? `, ${phase.toLowerCase()}` : '') +
+    ')';
+  currentFile.textContent = data.currentFile
+    ? `Current: ${data.currentFile}`
+    : '';
+  stats.textContent =
+    `Points parsed: ${Number(data.pointsParsed).toLocaleString()} ` +
+    `· Records written: ${Number(data.recordsWritten).toLocaleString()} ` +
+    `· Output files: ${(data.filesCreated || []).length}`;
+
+  if (data.status === 'running' || data.status === 'scanning') {
+    progressBar.style.background = 'linear-gradient(90deg, #8e24aa, #ba68c8)';
+  } else if (data.status === 'completed') {
+    progressBar.style.background = '#4caf50';
+  } else if (data.status === 'cancelled') {
+    progressBar.style.background = '#ff9800';
+  } else if (data.status === 'error') {
+    progressBar.style.background = '#f44336';
+  }
+}
+
+async function cancelGpxImport() {
+  if (!currentGpxImportJobId) return;
+  const cancelBtn = document.getElementById('cancelGpxImportBtn');
+  cancelBtn.disabled = true; // spam-proof
+  try {
+    const response = await fetch(
+      `/plugins/signalk-parquet/api/import/gpx/cancel/${currentGpxImportJobId}`,
+      { method: 'POST' }
+    );
+    // 400 here means the job is already done — race with the completion
+    // poll. Not worth alerting the user about.
+    if (response.ok) {
+      document.getElementById('gpxImportProgressText').textContent =
+        'Cancelling…';
+    }
+  } catch (error) {
+    // non-fatal; poll will pick up the final status anyway
+    console.error('Cancel request failed:', error);
+  }
+}
+
+window.scanGpxImport = scanGpxImport;
+window.startGpxImport = startGpxImport;
+window.cancelGpxImport = cancelGpxImport;
+
+document.addEventListener('DOMContentLoaded', () => {
+  initGpxDropZone();
+  refreshStartButtonState();
+
+  if (currentGpxImportJobId) {
+    const progressDiv = document.getElementById('gpxImportProgress');
+    if (progressDiv) {
+      progressDiv.style.display = 'block';
+      document.getElementById('cancelGpxImportBtn').disabled = false;
+      gpxImportPollInterval = setInterval(pollGpxImportProgress, 1000);
+    }
+  }
+});

--- a/src/api-routes.ts
+++ b/src/api-routes.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import { glob } from 'glob';
 import express, { Router } from 'express';
+import multer from 'multer';
 import { getAvailablePaths } from './utils/path-discovery';
 import { DuckDBInstance } from '@duckdb/node-api';
 import { DuckDBPool } from './utils/duckdb-pool';
@@ -38,6 +39,12 @@ import {
   ProcessCancelApiResponse,
 } from './types';
 import { MigrationService } from './services/migration-service';
+import { GPX_UPLOAD_MAX_FILE_BYTES, GPX_UPLOAD_MAX_FILES } from './constants';
+import {
+  GpxImportService,
+  DEFAULT_IMPORT_PATHS,
+  GpxImportPath,
+} from './services/gpx-import-service';
 import { AggregationService } from './services/aggregation-service';
 import { AggregationTier, HivePathBuilder } from './utils/hive-path-builder';
 import { isAngularPath } from './utils/angular-paths';
@@ -292,7 +299,12 @@ export function registerApiRoutes(
   // Returns sorted parquet files for a SignalK path, or null if the directory doesn't exist
   function getDataFilesForPath(signalkPath: string): {
     pathDir: string;
-    files: Array<{ name: string; path: string; size: number; modified: string }>;
+    files: Array<{
+      name: string;
+      path: string;
+      size: number;
+      modified: string;
+    }>;
   } | null {
     const selfContextPath = app.selfContext
       .replace(/\./g, '/')
@@ -675,11 +687,18 @@ export function registerApiRoutes(
 
           job.phase = 'Discovering local files...';
           // Only scan hive-partitioned files (tier=X/context=Y/path=Z/year=YYYY/day=DDD/)
-          const excludedDirs = ['/processed/', '/repaired/', '/failed/', '/quarantine/'];
+          const excludedDirs = [
+            '/processed/',
+            '/repaired/',
+            '/failed/',
+            '/quarantine/',
+          ];
           const allLocalFiles = await glob(
             path.join(dataDir, 'tier=*', '**', '*.parquet')
           );
-          const localFiles = allLocalFiles.filter(f => !excludedDirs.some(dir => f.includes(dir)));
+          const localFiles = allLocalFiles.filter(
+            f => !excludedDirs.some(dir => f.includes(dir))
+          );
           job.localFilesTotal = localFiles.length;
 
           const localKeys = new Map<string, { path: string; size: number }>();
@@ -885,11 +904,18 @@ export function registerApiRoutes(
           } else {
             job.phase = 'Scanning local files...';
             // Only sync hive-partitioned files (tier=X/context=Y/path=Z/year=YYYY/day=DDD/)
-            const excludedDirs = ['/processed/', '/repaired/', '/failed/', '/quarantine/'];
+            const excludedDirs = [
+              '/processed/',
+              '/repaired/',
+              '/failed/',
+              '/quarantine/',
+            ];
             const allLocalFiles = await glob(
               path.join(dataDir, 'tier=*', '**', '*.parquet')
             );
-            const localFiles = allLocalFiles.filter(f => !excludedDirs.some(dir => f.includes(dir)));
+            const localFiles = allLocalFiles.filter(
+              f => !excludedDirs.some(dir => f.includes(dir))
+            );
 
             job.phase = `Listing ${label} objects...`;
             job.progress = 10;
@@ -1829,7 +1855,12 @@ export function registerApiRoutes(
           });
         }
 
-        const analyzer = getSharedAnalyzer(config, app, state.getDataDirPath(), state);
+        const analyzer = getSharedAnalyzer(
+          config,
+          app,
+          state.getDataDirPath(),
+          state
+        );
 
         const startTime = Date.now();
         const testResult = await analyzer.testConnection();
@@ -1914,7 +1945,12 @@ export function registerApiRoutes(
         }
 
         // Use shared analyzer instance to maintain conversation state
-        const analyzer = getSharedAnalyzer(config, app, state.getDataDirPath(), state);
+        const analyzer = getSharedAnalyzer(
+          config,
+          app,
+          state.getDataDirPath(),
+          state
+        );
 
         // Build analysis request
         let analysisRequest: AnalysisRequest;
@@ -2033,7 +2069,12 @@ export function registerApiRoutes(
         );
 
         // Use shared analyzer instance to access stored conversations
-        const analyzer = getSharedAnalyzer(config, app, state.getDataDirPath(), state);
+        const analyzer = getSharedAnalyzer(
+          config,
+          app,
+          state.getDataDirPath(),
+          state
+        );
 
         // Process follow-up question
         const followUpRequest = {
@@ -2079,7 +2120,12 @@ export function registerApiRoutes(
 
         const limit = parseInt(req.query.limit || '20', 10);
 
-        const analyzer = getSharedAnalyzer(config, app, state.getDataDirPath(), state);
+        const analyzer = getSharedAnalyzer(
+          config,
+          app,
+          state.getDataDirPath(),
+          state
+        );
 
         const history = await analyzer.getAnalysisHistory(limit);
 
@@ -2137,7 +2183,12 @@ export function registerApiRoutes(
 
         const analysisId = req.params.id;
 
-        const analyzer = getSharedAnalyzer(config, app, state.getDataDirPath(), state);
+        const analyzer = getSharedAnalyzer(
+          config,
+          app,
+          state.getDataDirPath(),
+          state
+        );
 
         const result = await analyzer.deleteAnalysis(analysisId);
 
@@ -2171,7 +2222,10 @@ export function registerApiRoutes(
     '/api/vessel-context',
     async (_: TypedRequest, res: TypedResponse<any>) => {
       try {
-        const contextManager = new VesselContextManager(app, state.getDataDirPath());
+        const contextManager = new VesselContextManager(
+          app,
+          state.getDataDirPath()
+        );
         const context = await contextManager.getVesselContext();
 
         return res.json({
@@ -2201,7 +2255,10 @@ export function registerApiRoutes(
       try {
         const { vesselInfo, customContext } = req.body;
 
-        const contextManager = new VesselContextManager(app, state.getDataDirPath());
+        const contextManager = new VesselContextManager(
+          app,
+          state.getDataDirPath()
+        );
         const updatedContext = await contextManager.updateVesselContext(
           vesselInfo,
           customContext,
@@ -2230,7 +2287,10 @@ export function registerApiRoutes(
     '/api/vessel-context/refresh',
     async (_: TypedRequest, res: TypedResponse<any>) => {
       try {
-        const contextManager = new VesselContextManager(app, state.getDataDirPath());
+        const contextManager = new VesselContextManager(
+          app,
+          state.getDataDirPath()
+        );
         const refreshedContext = await contextManager.refreshVesselInfo();
 
         return res.json({
@@ -2278,7 +2338,10 @@ export function registerApiRoutes(
     '/api/vessel-context/claude-preview',
     async (_: TypedRequest, res: TypedResponse<any>) => {
       try {
-        const contextManager = new VesselContextManager(app, state.getDataDirPath());
+        const contextManager = new VesselContextManager(
+          app,
+          state.getDataDirPath()
+        );
         // Ensure context is loaded before generating preview
         await contextManager.getVesselContext();
         const claudeContext = contextManager.generateClaudeContext();
@@ -4236,6 +4299,432 @@ export function registerApiRoutes(
   });
 
   // ===========================================
+  // GPX IMPORT API ROUTES
+  // ===========================================
+
+  // Created lazily in routes below so state.parquetWriter is available at
+  // request time (not at plugin-start when the writer may not yet exist).
+  let gpxImportService: GpxImportService | undefined;
+  const getGpxImportService = (): GpxImportService => {
+    if (!state.parquetWriter) {
+      throw new Error(
+        'ParquetWriter not initialized — cannot import GPX files'
+      );
+    }
+    if (!gpxImportService) {
+      gpxImportService = new GpxImportService(app, state.parquetWriter);
+    }
+    return gpxImportService;
+  };
+
+  // Validate + defaulting for both the upload and server-directory routes.
+  // Returns a normalised slice of the service config, or a 400-ready error
+  // string. Kept in one place so the two routes can't drift apart.
+  const validateAndResolveImportOptions = (
+    requestedPaths: string[] | undefined,
+    contextOverride: string | undefined,
+    filenamePrefixOverride: string | undefined
+  ):
+    | {
+        ok: true;
+        paths: GpxImportPath[];
+        context: string;
+        filenamePrefix: string;
+      }
+    | { ok: false; error: string } => {
+    // De-duplicate while preserving order so a malformed client request
+    // doesn't fan out duplicate records into the same parquet file.
+    const requestedRaw =
+      requestedPaths && requestedPaths.length > 0
+        ? requestedPaths
+        : (DEFAULT_IMPORT_PATHS as string[]);
+    const requested = Array.from(new Set(requestedRaw));
+
+    const supported = new Set<string>(DEFAULT_IMPORT_PATHS);
+    const invalid = requested.filter(p => !supported.has(p));
+    if (invalid.length > 0) {
+      return {
+        ok: false,
+        error: `Unsupported paths: ${invalid.join(', ')}. Supported: ${DEFAULT_IMPORT_PATHS.join(', ')}`,
+      };
+    }
+
+    const context =
+      contextOverride && contextOverride.length > 0
+        ? contextOverride
+        : app.selfContext;
+    const filenamePrefix =
+      filenamePrefixOverride && filenamePrefixOverride.length > 0
+        ? filenamePrefixOverride
+        : `${state.currentConfig?.filenamePrefix || 'signalk_data'}_gpx`;
+
+    return {
+      ok: true,
+      paths: requested as GpxImportPath[],
+      context,
+      filenamePrefix,
+    };
+  };
+
+  // Per-request stash for upload-session metadata. A WeakMap keeps this
+  // off `req` itself so we don't need to widen Express's Request type
+  // with a one-off field, and the entry goes away automatically once the
+  // request object is gc'd.
+  interface UploadSession {
+    dir: string;
+    sessionId: string;
+  }
+  const uploadSessions = new WeakMap<express.Request, UploadSession>();
+
+  // Scan a directory for .gpx files
+  router.post('/api/import/gpx/scan', async (req, res) => {
+    try {
+      const { sourceDirectory } = req.body;
+      if (!sourceDirectory || typeof sourceDirectory !== 'string') {
+        return res.status(400).json({
+          success: false,
+          error: 'sourceDirectory is required',
+        });
+      }
+
+      const result = await getGpxImportService().scan(sourceDirectory);
+
+      return res.json({
+        success: true,
+        totalFiles: result.totalFiles,
+        totalSize: result.totalSize,
+        totalSizeMB: (result.totalSize / 1024 / 1024).toFixed(2),
+        files: result.files.map(f => ({
+          path: f.path,
+          name: path.basename(f.path),
+          sizeMB: (f.size / 1024 / 1024).toFixed(2),
+        })),
+      });
+    } catch (error) {
+      return res.status(500).json({
+        success: false,
+        error: (error as Error).message,
+      });
+    }
+  });
+
+  // Start a GPX import job
+  router.post('/api/import/gpx', async (req, res) => {
+    try {
+      const {
+        sourceDirectory,
+        sourceFiles,
+        context,
+        paths,
+        filenamePrefix,
+        deleteSource = false,
+      } = req.body as {
+        sourceDirectory?: string;
+        sourceFiles?: string[];
+        context?: string;
+        paths?: string[];
+        filenamePrefix?: string;
+        deleteSource?: boolean;
+      };
+
+      if (!sourceDirectory && (!sourceFiles || sourceFiles.length === 0)) {
+        return res.status(400).json({
+          success: false,
+          error: 'sourceDirectory or sourceFiles is required',
+        });
+      }
+
+      const resolved = validateAndResolveImportOptions(
+        paths,
+        context,
+        filenamePrefix
+      );
+      if (!resolved.ok) {
+        return res.status(400).json({ success: false, error: resolved.error });
+      }
+
+      const jobId = await getGpxImportService().import({
+        sourceDirectory,
+        sourceFiles,
+        targetDirectory: state.getDataDirPath(),
+        context: resolved.context,
+        paths: resolved.paths,
+        filenamePrefix: resolved.filenamePrefix,
+        deleteSourceAfterImport: deleteSource,
+        sourceLabel: 'gpx-import',
+      });
+
+      return res.json({
+        success: true,
+        jobId,
+        message: 'GPX import started',
+      });
+    } catch (error) {
+      return res.status(500).json({
+        success: false,
+        error: (error as Error).message,
+      });
+    }
+  });
+
+  // Progress for an import job
+  router.get('/api/import/gpx/progress/:jobId', (req, res) => {
+    try {
+      const { jobId } = req.params;
+      const progress = getGpxImportService().getProgress(jobId);
+
+      if (!progress) {
+        return res.status(404).json({
+          success: false,
+          error: 'Import job not found',
+        });
+      }
+
+      return res.json({
+        success: true,
+        ...progress,
+        bytesProcessedMB: (progress.bytesProcessed / 1024 / 1024).toFixed(2),
+      });
+    } catch (error) {
+      return res.status(500).json({
+        success: false,
+        error: (error as Error).message,
+      });
+    }
+  });
+
+  // Cancel an import job
+  router.post('/api/import/gpx/cancel/:jobId', (req, res) => {
+    try {
+      const { jobId } = req.params;
+      const cancelled = getGpxImportService().cancel(jobId);
+
+      if (!cancelled) {
+        return res.status(400).json({
+          success: false,
+          error: 'Import job not found or not running',
+        });
+      }
+
+      return res.json({
+        success: true,
+        message: 'Cancellation requested',
+      });
+    } catch (error) {
+      return res.status(500).json({
+        success: false,
+        error: (error as Error).message,
+      });
+    }
+  });
+
+  // Upload .gpx files via multipart form and immediately kick off an import.
+  //
+  // Files are streamed to a per-request temp directory under the plugin's
+  // data dir so that bulky uploads never stage through memory. The job id
+  // used for the upload session doubles as the upload dir name, which makes
+  // cleanup trivial — whether the job completes, is cancelled, or crashes.
+  //
+  // Form fields (multipart/form-data):
+  //   files           One or more .gpx files (field name 'files')
+  //   context         Optional SignalK context (default: self)
+  //   paths           Optional comma-separated SignalK paths
+  //   filenamePrefix  Optional filename prefix for emitted parquet files
+  const uploadStorage = multer.diskStorage({
+    destination: (req, _file, cb) => {
+      // Create the session directory on the first file so every file in the
+      // same upload request shares it. Keyed on the Request object via a
+      // WeakMap so we don't have to widen Express types with a one-off field.
+      // Surface ensureDirSync failures (permissions, full disk) through cb
+      // so multer rejects the upload cleanly instead of hanging the request.
+      try {
+        let session = uploadSessions.get(req);
+        if (!session) {
+          const sessionId = `upload_${Date.now()}_${Math.random().toString(36).substring(2, 8)}`;
+          const dir = path.join(
+            state.getDataDirPath(),
+            'gpx-uploads',
+            sessionId
+          );
+          fs.ensureDirSync(dir);
+          session = { dir, sessionId };
+          uploadSessions.set(req, session);
+        }
+        cb(null, session.dir);
+      } catch (err) {
+        cb(err as Error, '');
+      }
+    },
+    filename: (_req, file, cb) => {
+      // Preserve original filename so the import log is informative; strip
+      // path components to defeat any path-traversal via the upload name.
+      const safe = path.basename(file.originalname).replace(/[^\w.\-]/g, '_');
+      cb(null, safe);
+    },
+  });
+
+  const uploadFilter = (
+    _req: express.Request,
+    file: Express.Multer.File,
+    cb: multer.FileFilterCallback
+  ) => {
+    if (!file.originalname.toLowerCase().endsWith('.gpx')) {
+      cb(
+        new Error(`Only .gpx files are accepted (got '${file.originalname}')`)
+      );
+      return;
+    }
+    cb(null, true);
+  };
+
+  const gpxUpload = multer({
+    storage: uploadStorage,
+    fileFilter: uploadFilter,
+    limits: {
+      fileSize: GPX_UPLOAD_MAX_FILE_BYTES,
+      files: GPX_UPLOAD_MAX_FILES,
+    },
+  });
+
+  router.post(
+    '/api/import/gpx/upload',
+    gpxUpload.array('files'),
+    async (req, res) => {
+      const session = uploadSessions.get(req);
+      const uploadDir = session?.dir;
+      const files = (req.files as Express.Multer.File[]) || [];
+
+      try {
+        if (files.length === 0 || !uploadDir) {
+          return res.status(400).json({
+            success: false,
+            error: 'No .gpx files received',
+          });
+        }
+
+        const body = req.body as {
+          context?: string;
+          paths?: string; // form fields are strings; accept CSV
+          filenamePrefix?: string;
+        };
+
+        const requested =
+          body.paths && body.paths.trim().length > 0
+            ? body.paths
+                .split(',')
+                .map(s => s.trim())
+                .filter(Boolean)
+            : undefined;
+
+        const resolved = validateAndResolveImportOptions(
+          requested,
+          body.context,
+          body.filenamePrefix
+        );
+        if (!resolved.ok) {
+          return res
+            .status(400)
+            .json({ success: false, error: resolved.error });
+        }
+
+        const jobId = await getGpxImportService().import({
+          sourceFiles: files.map(f => f.path),
+          targetDirectory: state.getDataDirPath(),
+          context: resolved.context,
+          paths: resolved.paths,
+          filenamePrefix: resolved.filenamePrefix,
+          deleteSourceAfterImport: true, // uploaded temp files — always clean up
+          sourceLabel: 'gpx-import',
+        });
+
+        // Remove the per-upload staging dir when the job finishes. Polls the
+        // service rather than taking a callback because the service is the
+        // existing job-progress model; kept bounded below so a TTL'd progress
+        // entry (job deleted at 30 min) doesn't leak the timer forever.
+        const service = getGpxImportService();
+        const POLL_MS = 1000;
+        const MAX_POLL_MS = 60 * 60 * 1000; // 1h — well past any realistic import
+        const startedAt = Date.now();
+        const cleanup = setInterval(() => {
+          const progress = service.getProgress(jobId);
+          const finished =
+            progress &&
+            (progress.status === 'completed' ||
+              progress.status === 'cancelled' ||
+              progress.status === 'error');
+          const progressGone = progress === null; // TTL evicted it — nothing more we can learn
+          const pastDeadline = Date.now() - startedAt > MAX_POLL_MS;
+          if (finished || progressGone || pastDeadline) {
+            clearInterval(cleanup);
+            fs.remove(uploadDir).catch(() => {
+              // Best-effort: if remove fails, the dir stays around; not critical.
+            });
+          }
+        }, POLL_MS);
+
+        return res.json({
+          success: true,
+          jobId,
+          filesReceived: files.length,
+          message: 'Upload complete, GPX import started',
+        });
+      } catch (error) {
+        // On error before the job starts, remove the uploaded files so
+        // repeated failed attempts don't leak disk space.
+        if (uploadDir) {
+          fs.remove(uploadDir).catch(() => {
+            // ignore
+          });
+        }
+        return res.status(500).json({
+          success: false,
+          error: (error as Error).message,
+        });
+      }
+    }
+  );
+
+  // Multer errors (e.g. unsupported file type, size limit exceeded) surface
+  // as errors thrown from the middleware. Convert them to clean JSON 400s.
+  router.use(
+    '/api/import/gpx/upload',
+    (
+      err: Error,
+      _req: express.Request,
+      res: express.Response,
+      next: express.NextFunction
+    ): void => {
+      if (err) {
+        res.status(400).json({
+          success: false,
+          error: err.message,
+        });
+        return;
+      }
+      next();
+    }
+  );
+
+  // List all import jobs
+  router.get('/api/import/gpx/jobs', (_req, res) => {
+    try {
+      const service = getGpxImportService();
+      const jobIds = service.getJobIds();
+      const jobs = jobIds.map(id => service.getProgress(id)).filter(Boolean);
+
+      return res.json({
+        success: true,
+        jobs,
+      });
+    } catch (error) {
+      return res.status(500).json({
+        success: false,
+        error: (error as Error).message,
+      });
+    }
+  });
+
+  // ===========================================
   // AGGREGATION API ROUTES
   // ===========================================
 
@@ -4771,7 +5260,9 @@ export function registerApiRoutes(
                   );
                   const cols = schemaResult
                     .getRowObjects()
-                    .map((r: Record<string, unknown>) => r.column_name as string);
+                    .map(
+                      (r: Record<string, unknown>) => r.column_name as string
+                    );
                   isPositionPath =
                     cols.includes('value_latitude') &&
                     cols.includes('value_longitude');

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,3 +15,29 @@
  * 25 m/s ≈ 48.6 kn — well above any sailing/power vessel's realistic top speed.
  */
 export const POSITION_MAX_SPEED_MPS = 25;
+
+/**
+ * GPX import: per-file upload size cap, in bytes.
+ *
+ * The whole file is read into memory and then fanned out into one
+ * DataRecord per (point x selected SK path), so the conservative cap
+ * is much lower than what multer's wire limit would allow. A 50 MB
+ * GPX is roughly half a million trkpts; with four default paths that
+ * peaks around 2 GB of working set, which is the upper bound for a
+ * Pi-class host. Raise only after the importer streams instead of
+ * buffering (parquet-writer.ts:writeParquetBatched is available for
+ * this; it just isn't wired into the import path yet).
+ */
+export const GPX_UPLOAD_MAX_FILE_BYTES = 50 * 1024 * 1024;
+
+/**
+ * GPX import: maximum number of files per multipart upload request.
+ */
+export const GPX_UPLOAD_MAX_FILES = 500;
+
+/**
+ * GPX import: how long a finished job's progress entry sticks around for
+ * the UI to poll, in milliseconds. Mirrors MIGRATION_JOB_TTL_MS in
+ * MigrationService - kept identical so both jobs feel the same.
+ */
+export const IMPORT_JOB_TTL_MS = 30 * 60 * 1000;

--- a/src/services/gpx-import-service.ts
+++ b/src/services/gpx-import-service.ts
@@ -1,0 +1,554 @@
+/**
+ * GPX Import Service
+ *
+ * Imports historical GPS tracks from GPX files into the Hive-partitioned
+ * parquet store. Each <trkpt> with a valid <time> is expanded into SignalK
+ * delta-style records for the configured paths (position, SOG, COG,
+ * altitude) and written directly as parquet files, bypassing the SQLite
+ * buffer (bulk historical load).
+ *
+ * Follows the same progress-tracking / cancellable-job pattern as
+ * MigrationService.
+ *
+ * When adding a new SignalK path:
+ *   1. Extend the GpxImportPath union below
+ *   2. Append to DEFAULT_IMPORT_PATHS
+ *   3. Add a case in pointToValue() that maps the <trkpt> to the value
+ *      in SignalK units (m/s, radians, etc.)
+ *   4. Extend the GpxPoint interface in gpx-parser.ts if a new tag must
+ *      be parsed out of the GPX
+ */
+
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { glob } from 'glob';
+import { ServerAPI } from '@signalk/server-api';
+import { DataRecord, ParquetWriter } from '../types';
+import { HivePathBuilder } from '../utils/hive-path-builder';
+import { parseGpx, GpxPoint } from '../utils/gpx-parser';
+import { IMPORT_JOB_TTL_MS } from '../constants';
+
+export type GpxImportPath =
+  | 'navigation.position'
+  | 'navigation.speedOverGround'
+  | 'navigation.courseOverGroundTrue'
+  | 'navigation.gnss.antennaAltitude';
+
+export const DEFAULT_IMPORT_PATHS: GpxImportPath[] = [
+  'navigation.position',
+  'navigation.speedOverGround',
+  'navigation.courseOverGroundTrue',
+  'navigation.gnss.antennaAltitude',
+];
+
+export interface GpxImportConfig {
+  sourceDirectory?: string; // Scan recursively for .gpx files
+  sourceFiles?: string[]; // Explicit list (absolute paths). Used if set.
+  targetDirectory: string; // Typically state.getDataDirPath()
+  context: string; // SignalK context, e.g. 'vessels.urn:mrn:...'
+  paths: GpxImportPath[]; // Which SK paths to emit per point
+  filenamePrefix: string; // Output parquet filename prefix
+  deleteSourceAfterImport: boolean;
+  sourceLabel: string; // Written into record.source_label
+}
+
+export interface GpxImportProgress {
+  jobId: string;
+  status: 'scanning' | 'running' | 'completed' | 'cancelled' | 'error';
+  phase: 'scan' | 'parse' | 'write';
+  processed: number; // files processed
+  total: number; // files to process
+  percent: number;
+  currentFile?: string;
+  startTime: Date;
+  completedAt?: Date;
+  error?: string;
+  bytesProcessed: number;
+  pointsParsed: number;
+  pointsWritten: number; // includes fan-out across paths
+  recordsWritten: number; // parquet rows actually emitted
+  filesImported: number;
+  filesSkipped: number;
+  filesCreated: string[];
+  errors: string[];
+}
+
+export interface GpxScanResult {
+  totalFiles: number;
+  totalSize: number;
+  files: Array<{ path: string; size: number }>;
+}
+
+const importJobs = new Map<string, GpxImportProgress>();
+
+function scheduleImportJobCleanup(jobId: string) {
+  setTimeout(() => {
+    const job = importJobs.get(jobId);
+    if (job && job.status !== 'running') {
+      importJobs.delete(jobId);
+    }
+  }, IMPORT_JOB_TTL_MS);
+}
+
+export class GpxImportService {
+  private readonly app: ServerAPI;
+  private readonly parquetWriter: ParquetWriter;
+  private readonly hivePathBuilder: HivePathBuilder;
+
+  // Per-job cancellation. A set (rather than a single flag) so concurrent
+  // imports don't trample each other's state — cancelling one job never
+  // cancels another.
+  private readonly cancelledJobs: Set<string> = new Set();
+
+  constructor(app: ServerAPI, parquetWriter: ParquetWriter) {
+    this.app = app;
+    this.parquetWriter = parquetWriter;
+    this.hivePathBuilder = new HivePathBuilder();
+  }
+
+  /**
+   * Scan a directory for .gpx files (non-destructive dry run).
+   */
+  async scan(sourceDirectory: string): Promise<GpxScanResult> {
+    const pattern = path.join(sourceDirectory, '**', '*.gpx');
+    const matches = await glob(pattern, { nocase: true });
+
+    const files: Array<{ path: string; size: number }> = [];
+    let totalSize = 0;
+
+    for (const file of matches) {
+      try {
+        const stats = await fs.stat(file);
+        files.push({ path: file, size: stats.size });
+        totalSize += stats.size;
+      } catch (error) {
+        this.app.debug(`Failed to stat ${file}: ${(error as Error).message}`);
+      }
+    }
+
+    return { totalFiles: files.length, totalSize, files };
+  }
+
+  /**
+   * Start an import job. Runs asynchronously; poll progress via getProgress.
+   *
+   * Validates the requested SK paths against DEFAULT_IMPORT_PATHS even
+   * though the route layer already does — defense in depth so a future
+   * non-route caller can't slip an unsupported path through to
+   * pointToValue (which has no default branch).
+   */
+  async import(config: GpxImportConfig): Promise<string> {
+    const supported = new Set<string>(DEFAULT_IMPORT_PATHS);
+    const invalid = config.paths.filter(p => !supported.has(p));
+    if (invalid.length > 0) {
+      throw new Error(
+        `Unsupported paths: ${invalid.join(', ')}. Supported: ${DEFAULT_IMPORT_PATHS.join(', ')}`
+      );
+    }
+
+    const jobId = `import_${Date.now()}_${Math.random().toString(36).substring(2, 8)}`;
+
+    const progress: GpxImportProgress = {
+      jobId,
+      status: 'scanning',
+      phase: 'scan',
+      processed: 0,
+      total: 0,
+      percent: 0,
+      startTime: new Date(),
+      bytesProcessed: 0,
+      pointsParsed: 0,
+      pointsWritten: 0,
+      recordsWritten: 0,
+      filesImported: 0,
+      filesSkipped: 0,
+      filesCreated: [],
+      errors: [],
+    };
+
+    importJobs.set(jobId, progress);
+
+    this.runImport(jobId, config)
+      .catch(error => {
+        const job = importJobs.get(jobId);
+        if (job) {
+          job.status = 'error';
+          job.error = (error as Error).message;
+          job.completedAt = new Date();
+        }
+      })
+      .finally(() => {
+        // Drop the cancellation flag once the job is no longer running
+        // so the set doesn't grow unboundedly across the plugin's lifetime.
+        this.cancelledJobs.delete(jobId);
+      });
+
+    return jobId;
+  }
+
+  /**
+   * Main orchestration: resolve file list, parse each, group records by
+   * (path, day), write one parquet per group into the Hive layout.
+   */
+  private async runImport(
+    jobId: string,
+    config: GpxImportConfig
+  ): Promise<void> {
+    const progress = importJobs.get(jobId);
+    if (!progress) return;
+
+    try {
+      progress.phase = 'scan';
+      progress.status = 'scanning';
+
+      // Resolve source files
+      const gpxFiles: string[] = [];
+      if (config.sourceFiles && config.sourceFiles.length > 0) {
+        gpxFiles.push(...config.sourceFiles);
+      } else if (config.sourceDirectory) {
+        const pattern = path.join(config.sourceDirectory, '**', '*.gpx');
+        const matches = await glob(pattern, { nocase: true });
+        gpxFiles.push(...matches);
+      }
+
+      progress.total = gpxFiles.length;
+
+      if (gpxFiles.length === 0) {
+        progress.status = 'completed';
+        progress.completedAt = new Date();
+        scheduleImportJobCleanup(jobId);
+        return;
+      }
+
+      // Resolve vessels.self to concrete context (stored on disk)
+      const resolvedContext =
+        config.context === 'vessels.self'
+          ? this.app.selfContext
+          : config.context;
+
+      // Per-job metadata cache: app.getMetadata(path) is lookup-cheap but
+      // the repeated calls are noisy in a busy server. One read per path
+      // per job, mirrored from the live handler in data-handler.ts.
+      const metadataCache = this.buildMetadataCache(config.paths);
+
+      progress.status = 'running';
+
+      for (let i = 0; i < gpxFiles.length; i++) {
+        if (this.cancelledJobs.has(jobId)) {
+          progress.status = 'cancelled';
+          progress.completedAt = new Date();
+          scheduleImportJobCleanup(jobId);
+          return;
+        }
+
+        const file = gpxFiles[i];
+        progress.currentFile = path.basename(file);
+        progress.processed = i + 1;
+        progress.percent = Math.round(((i + 1) / gpxFiles.length) * 100);
+        progress.phase = 'parse'; // reset before each file; importFile flips to 'write' once it starts emitting
+
+        try {
+          const stats = await fs.stat(file);
+          const imported = await this.importFile(
+            jobId,
+            file,
+            resolvedContext,
+            config,
+            progress,
+            metadataCache
+          );
+
+          if (imported) {
+            progress.filesImported++;
+            progress.bytesProcessed += stats.size;
+
+            if (config.deleteSourceAfterImport) {
+              await fs.remove(file);
+            }
+          } else {
+            progress.filesSkipped++;
+          }
+        } catch (error) {
+          const errorMsg = `Failed to import ${file}: ${(error as Error).message}`;
+          this.app.debug(errorMsg);
+          progress.errors.push(errorMsg);
+          progress.filesSkipped++;
+        }
+      }
+
+      progress.status = 'completed';
+      progress.completedAt = new Date();
+      scheduleImportJobCleanup(jobId);
+    } catch (error) {
+      progress.status = 'error';
+      progress.error = (error as Error).message;
+      progress.completedAt = new Date();
+      scheduleImportJobCleanup(jobId);
+    }
+  }
+
+  /**
+   * Look up SignalK metadata once per job for each requested path. Mirrors
+   * what data-handler.ts does on every live delta — for imports we just
+   * cache it once. Failures are silent (metadata is best-effort and the
+   * record stays valid without it).
+   */
+  private buildMetadataCache(
+    paths: GpxImportPath[]
+  ): Map<string, object | undefined> {
+    const cache = new Map<string, object | undefined>();
+    for (const p of paths) {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const meta = (this.app as any).getMetadata?.(p);
+        cache.set(p, meta || undefined);
+      } catch {
+        cache.set(p, undefined);
+      }
+    }
+    return cache;
+  }
+
+  /**
+   * Parse a single GPX file and write its points to the parquet store.
+   * Returns true if at least one parquet file was produced.
+   */
+  private async importFile(
+    jobId: string,
+    sourcePath: string,
+    resolvedContext: string,
+    config: GpxImportConfig,
+    progress: GpxImportProgress,
+    metadataCache: Map<string, object | undefined>
+  ): Promise<boolean> {
+    const xml = await fs.readFile(sourcePath, 'utf8');
+    const parsed = parseGpx(xml);
+    progress.pointsParsed += parsed.totalPoints;
+
+    if (parsed.totalPoints === 0) {
+      return false;
+    }
+
+    // Flatten all trkpts across all tracks; keep only points with a timestamp
+    const allPoints: GpxPoint[] = [];
+    for (const trk of parsed.tracks) {
+      for (const pt of trk.points) {
+        if (pt.time) {
+          allPoints.push(pt);
+        }
+      }
+    }
+
+    if (allPoints.length === 0) {
+      return false;
+    }
+
+    // Group records by (signalkPath, dayKey) so each group becomes one parquet file.
+    // dayKey uses UTC year+dayOfYear which matches the Hive partition granularity.
+    type GroupKey = string; // `${signalkPath}|${year}|${dayOfYear}`
+    const groups = new Map<
+      GroupKey,
+      { records: DataRecord[]; signalkPath: GpxImportPath; anchor: Date }
+    >();
+
+    for (const pt of allPoints) {
+      const ts = pt.time!;
+      const year = ts.getUTCFullYear();
+      const dayOfYear = this.hivePathBuilder.getDayOfYear(ts);
+
+      for (const skPath of config.paths) {
+        const value = this.pointToValue(skPath, pt);
+        if (value === undefined) continue;
+
+        const record = this.buildRecord(
+          skPath,
+          resolvedContext,
+          ts,
+          value,
+          config.sourceLabel,
+          path.basename(sourcePath),
+          metadataCache.get(skPath)
+        );
+
+        const key: GroupKey = `${skPath}|${year}|${dayOfYear}`;
+        let group = groups.get(key);
+        if (!group) {
+          group = { records: [], signalkPath: skPath, anchor: ts };
+          groups.set(key, group);
+        }
+        group.records.push(record);
+        progress.pointsWritten++;
+      }
+    }
+
+    progress.phase = 'write';
+
+    for (const [, group] of groups) {
+      if (this.cancelledJobs.has(jobId)) return true; // partial import counts
+
+      const filePath = this.buildHiveFilePath(
+        config.targetDirectory,
+        resolvedContext,
+        group.signalkPath,
+        group.anchor,
+        config.filenamePrefix
+      );
+
+      await fs.ensureDir(path.dirname(filePath));
+      const tempFilePath = filePath + '.tmp';
+
+      try {
+        // ParquetWriter.writeRecords validates the file before returning
+        // (see validateParquetFile in parquet-writer.ts — checks minimum
+        // size and round-trips through the reader) and throws on failure.
+        // We don't re-validate here; on success the temp file is present
+        // and safe to atomic-rename to the final destination.
+        await this.parquetWriter.writeRecords(tempFilePath, group.records);
+        await fs.rename(tempFilePath, filePath);
+        progress.filesCreated.push(filePath);
+        progress.recordsWritten += group.records.length;
+      } catch (error) {
+        try {
+          await fs.remove(tempFilePath);
+        } catch {
+          // ignore cleanup failures
+        }
+        throw error;
+      }
+    }
+
+    return groups.size > 0;
+  }
+
+  private buildHiveFilePath(
+    basePath: string,
+    context: string,
+    signalkPath: string,
+    anchorTimestamp: Date,
+    filenamePrefix: string
+  ): string {
+    // Imports always land in tier=raw: they're un-aggregated point data
+    // (the same shape as live SK deltas write) and should be re-aggregated
+    // through the same raw -> 5s -> 60s -> 1h pipeline as live data via
+    // AggregationService.aggregateDate().
+    const dirPath = this.hivePathBuilder.buildPath(
+      basePath,
+      'raw',
+      context,
+      signalkPath,
+      anchorTimestamp
+    );
+    // Wall-clock timestamp so two import jobs writing to the same partition
+    // don't collide. Millisecond resolution + random suffix gives safe
+    // uniqueness even with concurrent runs.
+    const now = new Date();
+    const timestampStr = now.toISOString().replace(/[:.]/g, '').slice(0, 18);
+    const randomSuffix = Math.random().toString(36).substring(2, 6);
+    return path.join(
+      dirPath,
+      `${filenamePrefix}_${timestampStr}_${randomSuffix}.parquet`
+    );
+  }
+
+  /**
+   * Convert a GPX point into the SignalK value for a given path.
+   * Returns undefined if the point lacks the needed field.
+   *
+   * Units:
+   * - navigation.position: object {latitude, longitude} in decimal degrees
+   * - navigation.speedOverGround: number in m/s (GPX <speed> is m/s)
+   * - navigation.courseOverGroundTrue: number in radians (GPX <course> is degrees → convert)
+   * - navigation.gnss.antennaAltitude: number in meters
+   *
+   * When adding a new GpxImportPath, add a matching case here in the same
+   * unit as the SignalK path spec defines.
+   */
+  private pointToValue(skPath: GpxImportPath, pt: GpxPoint): unknown {
+    switch (skPath) {
+      case 'navigation.position':
+        return { latitude: pt.latitude, longitude: pt.longitude };
+      case 'navigation.speedOverGround':
+        return pt.speedMs;
+      case 'navigation.courseOverGroundTrue':
+        return pt.courseDeg !== undefined
+          ? (pt.courseDeg * Math.PI) / 180
+          : undefined;
+      case 'navigation.gnss.antennaAltitude':
+        return pt.elevation;
+    }
+  }
+
+  /**
+   * Build a DataRecord matching the shape produced by the live streambundle
+   * handler in data-handler.ts: scalar values go in `value`, object values
+   * go in `value_json` with their scalar properties flattened into
+   * `value_<key>` columns so downstream queries can read them directly.
+   * `meta` carries the SK metadata (units, displayUnits, etc.) so
+   * downstream consumers see the same units as live-captured rows.
+   *
+   * Kept inline (rather than shared with data-handler.ts) because the live
+   * path also populates source.$source, source.pgn etc. from the delta
+   * frame — fields we don't have here. A future refactor could extract
+   * the shared object-flattening helper; it isn't big enough to pay yet.
+   *
+   * `source.type: 'file'` is a plugin-local convention rather than one of
+   * SK's canonical source types (NMEA0183 / NMEA2000 / signalk). Anything
+   * filtering on canonical types won't match imported rows; if that
+   * matters in the future, we could expose it as a config option.
+   */
+  private buildRecord(
+    skPath: GpxImportPath,
+    context: string,
+    signalkTimestamp: Date,
+    value: unknown,
+    sourceLabel: string,
+    originalFilename: string,
+    meta: object | undefined
+  ): DataRecord {
+    const record: DataRecord = {
+      received_timestamp: new Date().toISOString(),
+      signalk_timestamp: signalkTimestamp.toISOString(),
+      context,
+      path: skPath,
+      value: null,
+      source: { label: sourceLabel, type: 'file', file: originalFilename },
+      source_label: sourceLabel,
+      source_type: 'file',
+      meta,
+    };
+
+    if (value !== null && typeof value === 'object') {
+      record.value_json = value;
+      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+        if (
+          typeof v === 'string' ||
+          typeof v === 'number' ||
+          typeof v === 'boolean'
+        ) {
+          (record as Record<string, unknown>)[`value_${k}`] = v;
+        }
+      }
+    } else {
+      record.value = value;
+    }
+
+    return record;
+  }
+
+  getProgress(jobId: string): GpxImportProgress | null {
+    return importJobs.get(jobId) || null;
+  }
+
+  cancel(jobId: string): boolean {
+    const job = importJobs.get(jobId);
+    if (job && job.status === 'running') {
+      this.cancelledJobs.add(jobId);
+      return true;
+    }
+    return false;
+  }
+
+  getJobIds(): string[] {
+    return Array.from(importJobs.keys());
+  }
+}

--- a/src/utils/gpx-parser.ts
+++ b/src/utils/gpx-parser.ts
@@ -1,0 +1,153 @@
+/**
+ * Minimal GPX parser
+ *
+ * Extracts track points (<trkpt>) from a GPX file. Waypoints and routes are
+ * ignored — only trkpt elements carry the <time> tag needed for partitioning
+ * time-series data into the parquet store.
+ *
+ * Supports GPX 1.0 and 1.1. Uses regex-based extraction rather than a full
+ * XML parser to avoid adding a dependency; this is safe for GPX because the
+ * schema is shallow and well-defined.
+ *
+ * Example input fragment:
+ *   <trkpt lat="47.5" lon="8.7">
+ *     <ele>412.5</ele>
+ *     <time>2024-06-01T10:15:30Z</time>
+ *     <speed>5.14</speed>
+ *     <course>180.0</course>
+ *   </trkpt>
+ * Produces: { latitude: 47.5, longitude: 8.7, time: Date(...), elevation: 412.5, speedMs: 5.14, courseDeg: 180 }
+ */
+
+export interface GpxPoint {
+  latitude: number;
+  longitude: number;
+  time?: Date;
+  elevation?: number; // meters
+  speedMs?: number; // m/s
+  courseDeg?: number; // degrees true
+}
+
+export interface GpxTrack {
+  name?: string;
+  points: GpxPoint[];
+}
+
+export interface GpxParseResult {
+  tracks: GpxTrack[];
+  totalPoints: number;
+  firstTime?: Date;
+  lastTime?: Date;
+}
+
+// Real-world GPX exporters add namespace prefixes liberally (Garmin
+// Connect uses "gpxx:", some OpenCPN configs use "ns3:", certain Suunto
+// and Polar exporters use other ones). The (?:[\w-]+:)? group is
+// non-capturing so existing capture-group indices stay the same.
+
+// Match a single <trkpt ...>...</trkpt> block (possibly namespace-prefixed),
+// capturing attributes and inner content. Multiline because trkpt contents
+// span several lines.
+const TRKPT_RE =
+  /<(?:[\w-]+:)?trkpt\b([^>]*)>([\s\S]*?)<\/(?:[\w-]+:)?trkpt>|<(?:[\w-]+:)?trkpt\b([^>]*)\/>/g;
+
+// Match <trk>...</trk>; within each we parse name and trkpt elements.
+const TRK_RE = /<(?:[\w-]+:)?trk\b[^>]*>([\s\S]*?)<\/(?:[\w-]+:)?trk>/g;
+
+const NAME_RE = /<(?:[\w-]+:)?name\b[^>]*>([\s\S]*?)<\/(?:[\w-]+:)?name>/;
+
+function extractAttr(attrs: string, name: string): string | undefined {
+  // e.g. extract lat="47.5" from ' lat="47.5" lon="8.7"'
+  const re = new RegExp(`\\b${name}\\s*=\\s*"([^"]*)"`);
+  const m = attrs.match(re);
+  return m ? m[1] : undefined;
+}
+
+function extractTag(inner: string, tag: string): string | undefined {
+  // Allow an optional namespace prefix on either the open or close tag,
+  // matching the broader tolerance in TRKPT_RE / TRK_RE / NAME_RE.
+  const re = new RegExp(
+    `<(?:[\\w-]+:)?${tag}\\b[^>]*>([\\s\\S]*?)<\\/(?:[\\w-]+:)?${tag}>`,
+    'i'
+  );
+  const m = inner.match(re);
+  return m ? m[1].trim() : undefined;
+}
+
+function parseFloatOrUndef(s: string | undefined): number | undefined {
+  if (s === undefined) return undefined;
+  const n = parseFloat(s);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function parsePoint(attrs: string, inner: string): GpxPoint | null {
+  const lat = parseFloatOrUndef(extractAttr(attrs, 'lat'));
+  const lon = parseFloatOrUndef(extractAttr(attrs, 'lon'));
+  if (lat === undefined || lon === undefined) {
+    return null;
+  }
+
+  const timeStr = extractTag(inner, 'time');
+  let time: Date | undefined;
+  if (timeStr) {
+    const d = new Date(timeStr);
+    if (!isNaN(d.getTime())) {
+      time = d;
+    }
+  }
+
+  return {
+    latitude: lat,
+    longitude: lon,
+    time,
+    elevation: parseFloatOrUndef(extractTag(inner, 'ele')),
+    speedMs: parseFloatOrUndef(extractTag(inner, 'speed')),
+    courseDeg: parseFloatOrUndef(extractTag(inner, 'course')),
+  };
+}
+
+/**
+ * Parse a GPX XML string into structured tracks.
+ *
+ * Points without a valid lat/lon are skipped. Points without <time> are
+ * still returned (caller may drop them) — the time field is undefined.
+ */
+export function parseGpx(xml: string): GpxParseResult {
+  const tracks: GpxTrack[] = [];
+  let totalPoints = 0;
+  let firstTime: Date | undefined;
+  let lastTime: Date | undefined;
+
+  let trkMatch: RegExpExecArray | null;
+  TRK_RE.lastIndex = 0;
+
+  while ((trkMatch = TRK_RE.exec(xml)) !== null) {
+    const trkInner = trkMatch[1];
+    const nameMatch = trkInner.match(NAME_RE);
+    const name = nameMatch ? nameMatch[1].trim() : undefined;
+
+    const points: GpxPoint[] = [];
+    let ptMatch: RegExpExecArray | null;
+    TRKPT_RE.lastIndex = 0;
+
+    while ((ptMatch = TRKPT_RE.exec(trkInner)) !== null) {
+      // Self-closing form uses group 3; otherwise group 1 + 2
+      const attrs = ptMatch[1] ?? ptMatch[3] ?? '';
+      const inner = ptMatch[2] ?? '';
+      const pt = parsePoint(attrs, inner);
+      if (!pt) continue;
+
+      points.push(pt);
+      totalPoints++;
+
+      if (pt.time) {
+        if (!firstTime || pt.time < firstTime) firstTime = pt.time;
+        if (!lastTime || pt.time > lastTime) lastTime = pt.time;
+      }
+    }
+
+    tracks.push({ name, points });
+  }
+
+  return { tracks, totalPoints, firstTime, lastTime };
+}


### PR DESCRIPTION
Adds a GPX import workflow so historical tracks (other vessels, handhelds, archives) can be loaded into the Hive-partitioned parquet store without going through the live subscription path.

**New routes** under `/api/import/gpx/*`: scan, upload (multipart, `multer`), server-directory import, progress, cancel, jobs.

**Admin UI** (Status tab): drag-and-drop / click-to-pick uploader with per-path checkboxes, progress polling, cancel. Server-directory mode kept under an Advanced details block for USB-drive-style bulk imports on the host.

**Write path**: records are parsed, fanned out to the selected SK paths, grouped by (context, path, UTC day) and written directly to `tier=raw` via `ParquetWriter.writeRecords` — same layout as `ParquetExportService`. Bypasses the SQLite buffer (buffer is sized for live streams). `source_label: "gpx-import"` tags imported records.

**Unit handling**: GPX `<speed>` → m/s (pass-through), `<ele>` → m (pass-through), `<course>` → rad (degrees→radians to match SignalK convention). Points without `<time>` are skipped.

## Test plan

- [x] `npm run build` clean.
- [x] Small GPX (105 points, position-only) imports to the expected Hive path; schema and `source_label` correct.
- [x] 20 000-point multi-day GPX produces one parquet per (path, UTC day); unit conversion verified (`90°` → `π/2` rad; `2.5` m/s unchanged).
- [x] Cancel mid-import: atomic `.tmp` rename prevents partial files; no orphans.
- [x] Browser upload path: multipart → job → cleanup of per-upload temp dir after completion.