### PR TITLE
feat: per-year compaction of parquet partitions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4066,6 +4066,161 @@
                 ></div>
               </div>
             </div>
+
+            <!-- Compaction Section -->
+            <div
+              id="compactionPanel"
+              style="
+                margin-top: 30px;
+                padding: 20px;
+                background: #e8eaf6;
+                border-radius: 8px;
+                border: 2px solid #3949ab;
+              "
+            >
+              <h3 style="margin-top: 0; color: #1a237e">
+                🗜️ Compact old years
+              </h3>
+              <p style="color: #666; margin-bottom: 15px">
+                Merges per-day parquet files within each
+                (tier, context, path, year) group into a single per-year
+                file, then deletes the source day-files. Run this on a
+                long-running store to keep DuckDB queries fast and the
+                filesystem light. Only completed years (strictly before
+                the cutoff) are touched.
+              </p>
+
+              <div
+                style="
+                  display: grid;
+                  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+                  gap: 10px;
+                "
+              >
+                <div class="form-group">
+                  <label for="compactTier">Tier</label>
+                  <select id="compactTier" style="width: 100%">
+                    <option value="raw" selected>raw</option>
+                    <option value="5s">5s</option>
+                    <option value="60s">60s</option>
+                    <option value="1h">1h</option>
+                  </select>
+                </div>
+                <div class="form-group">
+                  <label for="compactBeforeYear">Compact years before</label>
+                  <input
+                    type="number"
+                    id="compactBeforeYear"
+                    placeholder="(default: this year)"
+                    style="width: 100%"
+                    min="2000"
+                    max="2099"
+                  />
+                </div>
+                <div class="form-group">
+                  <label for="compactPathFilter"
+                    >Path filter (substring)</label
+                  >
+                  <input
+                    type="text"
+                    id="compactPathFilter"
+                    placeholder="(optional, e.g. navigation.)"
+                    style="width: 100%"
+                  />
+                </div>
+              </div>
+
+              <div
+                style="
+                  margin-top: 15px;
+                  display: flex;
+                  gap: 10px;
+                  flex-wrap: wrap;
+                "
+              >
+                <button
+                  onclick="scanCompaction()"
+                  style="background: #3949ab"
+                >
+                  🔍 Scan
+                </button>
+                <button
+                  onclick="startCompaction()"
+                  style="background: #4caf50"
+                  id="startCompactionBtn"
+                  disabled
+                >
+                  ▶️ Start Compaction
+                </button>
+                <button
+                  onclick="cancelCompaction()"
+                  style="background: #f44336"
+                  id="cancelCompactionBtn"
+                  disabled
+                >
+                  ❌ Cancel
+                </button>
+              </div>
+
+              <div
+                id="compactScanResults"
+                style="
+                  margin-top: 20px;
+                  display: none;
+                  padding: 15px;
+                  background: white;
+                  border-radius: 5px;
+                  border: 1px solid #ddd;
+                "
+              >
+                <h4 style="margin-top: 0">Scan results</h4>
+                <div id="compactScanContent"></div>
+              </div>
+
+              <div
+                id="compactionProgress"
+                style="
+                  margin-top: 20px;
+                  display: none;
+                  padding: 15px;
+                  background: white;
+                  border-radius: 5px;
+                  border: 1px solid #ddd;
+                "
+              >
+                <h4 style="margin-top: 0">Compaction progress</h4>
+                <div
+                  style="
+                    background: #e0e0e0;
+                    border-radius: 5px;
+                    height: 20px;
+                    overflow: hidden;
+                    margin-bottom: 10px;
+                  "
+                >
+                  <div
+                    id="compactionProgressBar"
+                    style="
+                      background: linear-gradient(90deg, #3949ab, #7986cb);
+                      height: 100%;
+                      width: 0%;
+                      transition: width 0.3s;
+                    "
+                  ></div>
+                </div>
+                <div id="compactionProgressText" aria-live="polite">
+                  0% complete
+                </div>
+                <div
+                  id="compactionCurrentGroup"
+                  style="color: #666; font-size: 0.9em; margin-top: 5px"
+                ></div>
+                <div
+                  id="compactionStats"
+                  style="color: #666; font-size: 0.9em; margin-top: 5px"
+                ></div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -4074,6 +4229,7 @@
     <script type="module" src="js/main.js"></script>
     <script src="js/migration.js"></script>
     <script src="js/import.js"></script>
+    <script src="js/compaction.js"></script>
 
     <!-- Analysis History Modal -->
     <div

--- a/public/js/compaction.js
+++ b/public/js/compaction.js
@@ -1,0 +1,370 @@
+/**
+ * Compaction UI
+ *
+ * Drives the /api/compact/* endpoints from the Status tab. Mirrors the
+ * scan-then-start-then-poll flow used by the migration and import UIs.
+ */
+
+let currentCompactionJobId = localStorage.getItem('compactionJobId') || null;
+let compactionPollInterval = null;
+// The exact config that produced the most recent successful scan. Start
+// posts this — not the live form values — so a user can't scan one
+// (tier, beforeYear, pathFilter) and then accidentally compact a
+// different set after editing the inputs. Cleared by invalidateScan()
+// on any form change.
+let lastCompactionScanConfig = null;
+
+const COMPACT_PHASE_LABEL = {
+  scan: 'Scanning',
+  compact: 'Compacting',
+};
+
+function explainCompactHttpError(response) {
+  if (response.status === 401) {
+    return 'Not logged in. Open the Signal K admin UI, log in, then try again from this tab.';
+  }
+  return `HTTP ${response.status} ${response.statusText || ''}`.trim();
+}
+
+function readCompactConfig() {
+  const tier = document.getElementById('compactTier').value;
+  const beforeYearRaw = document
+    .getElementById('compactBeforeYear')
+    .value.trim();
+  const pathFilter = document.getElementById('compactPathFilter').value.trim();
+  const body = { tier };
+  if (beforeYearRaw) {
+    const n = Number(beforeYearRaw);
+    if (Number.isFinite(n)) body.beforeYear = n;
+  }
+  if (pathFilter) body.pathFilter = pathFilter;
+  return body;
+}
+
+function invalidateCompactionScan() {
+  if (!lastCompactionScanConfig) return;
+  lastCompactionScanConfig = null;
+  const resultsDiv = document.getElementById('compactScanResults');
+  const contentDiv = document.getElementById('compactScanContent');
+  if (resultsDiv) resultsDiv.style.display = 'none';
+  if (contentDiv) contentDiv.innerHTML = '';
+  // Don't touch Start while a job is in flight; pollCompactionProgress
+  // owns the disabled state until terminal status. Otherwise reflect
+  // "no valid scan" by disabling Start.
+  if (!currentCompactionJobId) {
+    const startBtn = document.getElementById('startCompactionBtn');
+    if (startBtn) startBtn.disabled = true;
+  }
+}
+
+async function scanCompaction() {
+  const resultsDiv = document.getElementById('compactScanResults');
+  const contentDiv = document.getElementById('compactScanContent');
+  const startBtn = document.getElementById('startCompactionBtn');
+
+  resultsDiv.style.display = 'block';
+  contentDiv.innerHTML = '<p><span class="loading">Scanning…</span></p>';
+  startBtn.disabled = true;
+  // Snapshot the exact config we're scanning. Persisted on success so
+  // Start can reuse it; cleared on failure (or any form edit).
+  const scanConfig = readCompactConfig();
+  lastCompactionScanConfig = null;
+
+  try {
+    const response = await fetch('/plugins/signalk-parquet/api/compact/scan', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(scanConfig),
+    });
+
+    if (!response.ok) {
+      contentDiv.textContent = `Scan failed: ${explainCompactHttpError(response)}`;
+      return;
+    }
+    const data = await response.json();
+    if (!data.success) {
+      contentDiv.textContent = `Scan failed: ${data.error}`;
+      return;
+    }
+
+    if (data.totalGroups === 0) {
+      contentDiv.innerHTML = `
+        <p style="color: #666;">
+          No (path, year) groups need compacting in tier <code>${data.tier}</code>
+          (years before ${data.beforeYear}). Either there's nothing yet, or the
+          previous compaction has already merged everything.
+        </p>
+      `;
+      return;
+    }
+
+    contentDiv.innerHTML = `
+      <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin-bottom: 15px;">
+        <div style="background: #e8eaf6; padding: 10px; border-radius: 5px; text-align: center;">
+          <strong>Groups</strong><br>
+          <span style="font-size: 1.3em;">${data.totalGroups.toLocaleString()}</span>
+        </div>
+        <div style="background: #c5cae9; padding: 10px; border-radius: 5px; text-align: center;">
+          <strong>Source files</strong><br>
+          <span style="font-size: 1.3em;">${data.totalSourceFiles.toLocaleString()}</span>
+        </div>
+        <div style="background: #9fa8da; padding: 10px; border-radius: 5px; text-align: center;">
+          <strong>Source size</strong><br>
+          <span style="font-size: 1.3em;">${data.totalSourceMB} MB</span>
+        </div>
+      </div>
+      <p style="color: #666;">
+        Will produce <strong>${data.totalGroups.toLocaleString()}</strong>
+        new files (one per group) and remove the
+        <strong>${data.totalSourceFiles.toLocaleString()}</strong> source files.
+      </p>
+    `;
+
+    const tableWrap = document.createElement('details');
+    tableWrap.innerHTML =
+      '<summary style="cursor:pointer;color:#283593;font-weight:500;">Group breakdown</summary>';
+    const table = document.createElement('table');
+    table.style.cssText =
+      'width:100%;border-collapse:collapse;margin-top:10px;font-size:0.9em;';
+    table.innerHTML = `
+      <thead>
+        <tr style="background:#f5f5f5;">
+          <th style="text-align:left;padding:8px;border-bottom:2px solid #ddd;">Year</th>
+          <th style="text-align:left;padding:8px;border-bottom:2px solid #ddd;">Path</th>
+          <th style="text-align:left;padding:8px;border-bottom:2px solid #ddd;">Context</th>
+          <th style="text-align:right;padding:8px;border-bottom:2px solid #ddd;">Files</th>
+          <th style="text-align:right;padding:8px;border-bottom:2px solid #ddd;">Size</th>
+        </tr>
+      </thead>
+    `;
+    const tbody = document.createElement('tbody');
+    for (const g of data.groups.slice(0, 200)) {
+      const tr = document.createElement('tr');
+      const cells = [
+        String(g.year),
+        g.path,
+        g.context,
+        g.sourceFiles.toLocaleString(),
+        `${g.sourceMB} MB`,
+      ];
+      cells.forEach((text, idx) => {
+        const td = document.createElement('td');
+        td.style.padding = '6px 8px';
+        td.style.borderBottom = '1px solid #eee';
+        if (idx >= 3) td.style.textAlign = 'right';
+        td.style.fontFamily = idx === 1 || idx === 2 ? 'monospace' : '';
+        td.textContent = text;
+        tr.appendChild(td);
+      });
+      tbody.appendChild(tr);
+    }
+    table.appendChild(tbody);
+    tableWrap.appendChild(table);
+    if (data.groups.length > 200) {
+      const overflow = document.createElement('p');
+      overflow.style.color = '#666';
+      overflow.style.marginTop = '10px';
+      overflow.textContent = `Showing 200 of ${data.groups.length} groups`;
+      tableWrap.appendChild(overflow);
+    }
+    contentDiv.appendChild(tableWrap);
+
+    lastCompactionScanConfig = scanConfig;
+    startBtn.disabled = false;
+  } catch (error) {
+    contentDiv.textContent = `Scan failed: ${error.message}`;
+  }
+}
+
+async function startCompaction() {
+  const startBtn = document.getElementById('startCompactionBtn');
+  const cancelBtn = document.getElementById('cancelCompactionBtn');
+  const progressDiv = document.getElementById('compactionProgress');
+
+  // Refuse to start without a fresh scan. Without this, an edit after
+  // scan would compact a different set than the preview showed.
+  if (!lastCompactionScanConfig) {
+    alert('Run a scan first, or rescan after editing the inputs.');
+    return;
+  }
+
+  startBtn.disabled = true;
+  cancelBtn.disabled = false;
+  progressDiv.style.display = 'block';
+  document.getElementById('compactionProgressBar').style.width = '0%';
+  document.getElementById('compactionProgressBar').style.background =
+    'linear-gradient(90deg, #3949ab, #7986cb)';
+  document.getElementById('compactionProgressText').textContent = 'Starting…';
+  document.getElementById('compactionCurrentGroup').textContent = '';
+  document.getElementById('compactionStats').textContent = '';
+
+  try {
+    const response = await fetch('/plugins/signalk-parquet/api/compact', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(lastCompactionScanConfig),
+    });
+    if (!response.ok) {
+      alert(`Failed to start compaction: ${explainCompactHttpError(response)}`);
+      progressDiv.style.display = 'none';
+      cancelBtn.disabled = true;
+      startBtn.disabled = false;
+      return;
+    }
+    const data = await response.json();
+    if (!data.success) {
+      alert(`Failed to start compaction: ${data.error}`);
+      progressDiv.style.display = 'none';
+      cancelBtn.disabled = true;
+      startBtn.disabled = false;
+      return;
+    }
+    currentCompactionJobId = data.jobId;
+    localStorage.setItem('compactionJobId', data.jobId);
+    compactionPollInterval = setInterval(pollCompactionProgress, 1000);
+  } catch (error) {
+    alert(`Failed to start compaction: ${error.message}`);
+    progressDiv.style.display = 'none';
+    cancelBtn.disabled = true;
+    startBtn.disabled = false;
+  }
+}
+
+async function pollCompactionProgress() {
+  if (!currentCompactionJobId) return;
+
+  try {
+    const response = await fetch(
+      `/plugins/signalk-parquet/api/compact/progress/${currentCompactionJobId}`
+    );
+    if (response.status === 404) {
+      clearInterval(compactionPollInterval);
+      compactionPollInterval = null;
+      currentCompactionJobId = null;
+      localStorage.removeItem('compactionJobId');
+      document.getElementById('compactionProgress').style.display = 'none';
+      document.getElementById('cancelCompactionBtn').disabled = true;
+      document.getElementById('startCompactionBtn').disabled = false;
+      return;
+    }
+    if (!response.ok) return; // transient — keep polling
+
+    const data = await response.json();
+    updateCompactionProgress(data);
+
+    if (
+      data.status === 'completed' ||
+      data.status === 'cancelled' ||
+      data.status === 'error'
+    ) {
+      clearInterval(compactionPollInterval);
+      compactionPollInterval = null;
+      currentCompactionJobId = null;
+      localStorage.removeItem('compactionJobId');
+      document.getElementById('cancelCompactionBtn').disabled = true;
+      document.getElementById('startCompactionBtn').disabled = false;
+
+      if (data.status === 'completed') {
+        const before = Number(data.bytesBefore || 0);
+        const after = Number(data.bytesAfter || 0);
+        const ratio = before > 0 ? (after / before) * 100 : 0;
+        alert(
+          `Compaction complete.\n\n` +
+            `Groups compacted: ${data.groupsCompacted}\n` +
+            `Groups skipped:   ${data.groupsSkipped}\n` +
+            `Source files removed: ${data.filesRemoved}\n` +
+            `Size before: ${data.bytesBeforeMB} MB\n` +
+            `Size after:  ${data.bytesAfterMB} MB\n` +
+            `Saved:       ${data.savingsMB} MB (output is ${ratio.toFixed(1)}% of input)`
+        );
+      } else if (data.status === 'cancelled') {
+        alert('Compaction cancelled.');
+      } else if (data.status === 'error') {
+        alert(`Compaction failed: ${data.error}`);
+      }
+    }
+  } catch (error) {
+    console.error('Error polling compaction progress:', error);
+  }
+}
+
+function updateCompactionProgress(data) {
+  const bar = document.getElementById('compactionProgressBar');
+  const text = document.getElementById('compactionProgressText');
+  const current = document.getElementById('compactionCurrentGroup');
+  const stats = document.getElementById('compactionStats');
+
+  const phase = COMPACT_PHASE_LABEL[data.phase] || data.phase || '';
+  bar.style.width = `${data.percent}%`;
+  text.textContent =
+    `${data.percent}% complete (${data.processed}/${data.total} groups` +
+    (phase ? `, ${phase.toLowerCase()}` : '') +
+    ')';
+  current.textContent = data.currentGroup
+    ? `Current: ${data.currentGroup}`
+    : '';
+  stats.textContent =
+    `Compacted: ${data.groupsCompacted} ` +
+    `· Skipped: ${data.groupsSkipped} ` +
+    `· Source files removed: ${data.filesRemoved}`;
+
+  if (data.status === 'running' || data.status === 'scanning') {
+    bar.style.background = 'linear-gradient(90deg, #3949ab, #7986cb)';
+  } else if (data.status === 'completed') {
+    bar.style.background = '#4caf50';
+  } else if (data.status === 'cancelled') {
+    bar.style.background = '#ff9800';
+  } else if (data.status === 'error') {
+    bar.style.background = '#f44336';
+  }
+}
+
+async function cancelCompaction() {
+  if (!currentCompactionJobId) return;
+  const cancelBtn = document.getElementById('cancelCompactionBtn');
+  cancelBtn.disabled = true;
+  try {
+    const response = await fetch(
+      `/plugins/signalk-parquet/api/compact/cancel/${currentCompactionJobId}`,
+      { method: 'POST' }
+    );
+    if (response.ok) {
+      document.getElementById('compactionProgressText').textContent =
+        'Cancelling…';
+    }
+  } catch (error) {
+    console.error('Cancel request failed:', error);
+  }
+}
+
+window.scanCompaction = scanCompaction;
+window.startCompaction = startCompaction;
+window.cancelCompaction = cancelCompaction;
+
+document.addEventListener('DOMContentLoaded', () => {
+  // Any edit to the form inputs invalidates the previous scan: Start
+  // becomes disabled until a fresh scan against the new config runs.
+  for (const id of ['compactTier', 'compactBeforeYear', 'compactPathFilter']) {
+    const el = document.getElementById(id);
+    if (!el) continue;
+    el.addEventListener('input', invalidateCompactionScan);
+    el.addEventListener('change', invalidateCompactionScan);
+  }
+
+  if (currentCompactionJobId) {
+    const progressDiv = document.getElementById('compactionProgress');
+    if (progressDiv) {
+      progressDiv.style.display = 'block';
+      document.getElementById('cancelCompactionBtn').disabled = false;
+      // Disable Start while a previous job is still being polled.
+      // Pressing Start here would orphan the original job from the
+      // page (currentCompactionJobId gets overwritten and the existing
+      // poll interval is replaced) — the server would also refuse the
+      // second start as a conflict, but the UI shouldn't even let it
+      // be attempted. Re-enabled by pollCompactionProgress when the
+      // job reaches a terminal state.
+      document.getElementById('startCompactionBtn').disabled = true;
+      compactionPollInterval = setInterval(pollCompactionProgress, 1000);
+    }
+  }
+});

--- a/src/api-routes.ts
+++ b/src/api-routes.ts
@@ -45,6 +45,10 @@ import {
   DEFAULT_IMPORT_PATHS,
   GpxImportPath,
 } from './services/gpx-import-service';
+import {
+  CompactionConflictError,
+  CompactionService,
+} from './services/compaction-service';
 import { AggregationService } from './services/aggregation-service';
 import { AggregationTier, HivePathBuilder } from './utils/hive-path-builder';
 import { isAngularPath } from './utils/angular-paths';
@@ -4353,6 +4357,21 @@ export function registerApiRoutes(
       contextOverride && contextOverride.length > 0
         ? contextOverride
         : app.selfContext;
+    // Filename prefix lands in `path.join(dir, `${prefix}_${ts}_…`.parquet)`
+    // so an unconstrained value enables path traversal AND silently
+    // breaks compaction's single-quote filename invariant. Restrict to
+    // the same alphabet the live writer uses.
+    if (
+      filenamePrefixOverride !== undefined &&
+      filenamePrefixOverride.length > 0
+    ) {
+      if (!/^[A-Za-z0-9_-]{1,64}$/.test(filenamePrefixOverride)) {
+        return {
+          ok: false,
+          error: 'filenamePrefix must be 1-64 chars of [A-Za-z0-9_-]',
+        };
+      }
+    }
     const filenamePrefix =
       filenamePrefixOverride && filenamePrefixOverride.length > 0
         ? filenamePrefixOverride
@@ -4711,6 +4730,224 @@ export function registerApiRoutes(
       const service = getGpxImportService();
       const jobIds = service.getJobIds();
       const jobs = jobIds.map(id => service.getProgress(id)).filter(Boolean);
+
+      return res.json({
+        success: true,
+        jobs,
+      });
+    } catch (error) {
+      return res.status(500).json({
+        success: false,
+        error: (error as Error).message,
+      });
+    }
+  });
+
+  // ===========================================
+  // COMPACTION API ROUTES
+  // ===========================================
+  //
+  // Merges per-day parquet files within each (tier, context, path, year)
+  // group into a single per-year file. Long-term-storage hygiene: keeps
+  // DuckDB queries spanning years fast and the filesystem light. See
+  // src/services/compaction-service.ts for the layout details.
+
+  const compactionService = new CompactionService(app);
+
+  // Validate + normalise the body of /api/compact and /api/compact/scan.
+  // Tier is allow-listed; beforeYear is clamped to [2000, currentUTCYear]
+  // so an authenticated admin cannot accidentally compact the
+  // in-progress year via a high cutoff like 9999 (which would race live
+  // writes).
+  const COMPACTION_VALID_TIERS: AggregationTier[] = ['raw', '5s', '60s', '1h'];
+  const COMPACTION_MIN_YEAR = 2000;
+  const validateCompactionInput = (body: {
+    tier?: AggregationTier;
+    beforeYear?: number;
+    pathFilter?: string;
+  }):
+    | {
+        ok: true;
+        tier: AggregationTier;
+        beforeYear: number;
+        pathFilter?: string;
+      }
+    | { ok: false; error: string } => {
+    const tier = body.tier ?? 'raw';
+    if (!COMPACTION_VALID_TIERS.includes(tier)) {
+      return {
+        ok: false,
+        error: `Invalid tier: ${tier}. Must be one of: ${COMPACTION_VALID_TIERS.join(', ')}`,
+      };
+    }
+    const currentYear = new Date().getUTCFullYear();
+    let beforeYear = currentYear;
+    if (body.beforeYear !== undefined) {
+      if (
+        typeof body.beforeYear !== 'number' ||
+        !Number.isFinite(body.beforeYear) ||
+        !Number.isInteger(body.beforeYear)
+      ) {
+        return {
+          ok: false,
+          error: 'beforeYear must be an integer',
+        };
+      }
+      if (
+        body.beforeYear < COMPACTION_MIN_YEAR ||
+        body.beforeYear > currentYear
+      ) {
+        return {
+          ok: false,
+          error: `beforeYear must be between ${COMPACTION_MIN_YEAR} and ${currentYear}`,
+        };
+      }
+      beforeYear = body.beforeYear;
+    }
+    return { ok: true, tier, beforeYear, pathFilter: body.pathFilter };
+  };
+
+  router.post('/api/compact/scan', async (req, res) => {
+    try {
+      const validated = validateCompactionInput(req.body || {});
+      if (!validated.ok) {
+        return res.status(400).json({ success: false, error: validated.error });
+      }
+      const { tier, beforeYear: cutoff, pathFilter } = validated;
+
+      const plan = await compactionService.scan({
+        baseDirectory: state.getDataDirPath(),
+        tier,
+        beforeYear: cutoff,
+        pathFilter,
+      });
+
+      return res.json({
+        success: true,
+        tier,
+        beforeYear: cutoff,
+        totalGroups: plan.totalGroups,
+        totalSourceFiles: plan.totalSourceFiles,
+        totalSourceBytes: plan.totalSourceBytes,
+        totalSourceMB: (plan.totalSourceBytes / 1024 / 1024).toFixed(2),
+        groups: plan.groups.map(g => ({
+          tier: g.tier,
+          context: g.context,
+          path: g.path,
+          year: g.year,
+          sourceFiles: g.sourceFiles,
+          sourceMB: (g.sourceBytes / 1024 / 1024).toFixed(2),
+        })),
+      });
+    } catch (error) {
+      return res.status(500).json({
+        success: false,
+        error: (error as Error).message,
+      });
+    }
+  });
+
+  router.post('/api/compact', async (req, res) => {
+    try {
+      const validated = validateCompactionInput(req.body || {});
+      if (!validated.ok) {
+        return res.status(400).json({ success: false, error: validated.error });
+      }
+      const { tier, beforeYear: cutoff, pathFilter } = validated;
+
+      const jobId = await compactionService.compact({
+        baseDirectory: state.getDataDirPath(),
+        tier,
+        beforeYear: cutoff,
+        pathFilter,
+      });
+
+      return res.json({
+        success: true,
+        jobId,
+        tier,
+        beforeYear: cutoff,
+        message: 'Compaction started',
+      });
+    } catch (error) {
+      if (error instanceof CompactionConflictError) {
+        return res.status(409).json({
+          success: false,
+          error: error.message,
+        });
+      }
+      return res.status(500).json({
+        success: false,
+        error: (error as Error).message,
+      });
+    }
+  });
+
+  router.get('/api/compact/progress/:jobId', (req, res) => {
+    // Polled by the admin UI; matches the no-store header on validation
+    // and repair progress routes so a browser/proxy cache can't make a
+    // running job look stuck or hide a cancellation.
+    res.setHeader('Cache-Control', 'no-store');
+    try {
+      const { jobId } = req.params;
+      const progress = compactionService.getProgress(jobId);
+
+      if (!progress) {
+        return res.status(404).json({
+          success: false,
+          error: 'Compaction job not found',
+        });
+      }
+
+      return res.json({
+        success: true,
+        ...progress,
+        bytesBeforeMB: (progress.bytesBefore / 1024 / 1024).toFixed(2),
+        bytesAfterMB: (progress.bytesAfter / 1024 / 1024).toFixed(2),
+        savingsMB: (
+          (progress.bytesBefore - progress.bytesAfter) /
+          1024 /
+          1024
+        ).toFixed(2),
+      });
+    } catch (error) {
+      return res.status(500).json({
+        success: false,
+        error: (error as Error).message,
+      });
+    }
+  });
+
+  router.post('/api/compact/cancel/:jobId', (req, res) => {
+    try {
+      const { jobId } = req.params;
+      const cancelled = compactionService.cancel(jobId);
+
+      if (!cancelled) {
+        return res.status(400).json({
+          success: false,
+          error: 'Compaction job not found or not running',
+        });
+      }
+
+      return res.json({
+        success: true,
+        message: 'Cancellation requested',
+      });
+    } catch (error) {
+      return res.status(500).json({
+        success: false,
+        error: (error as Error).message,
+      });
+    }
+  });
+
+  router.get('/api/compact/jobs', (_req, res) => {
+    try {
+      const jobIds = compactionService.getJobIds();
+      const jobs = jobIds
+        .map(id => compactionService.getProgress(id))
+        .filter(Boolean);
 
       return res.json({
         success: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,11 @@ import e, { Router } from 'express';
 import { ParquetWriter } from './parquet-writer';
 import { registerHistoryApiRoute } from './HistoryAPI';
 import { registerApiRoutes } from './api-routes';
+import {
+  cleanupStrandedCompactionTempFiles,
+  quiesceAllCompactionJobs,
+  recoverStrandedCompactionTrash,
+} from './services/compaction-service';
 import { CACHE_SIZE } from './config/cache-defaults';
 // import { HistoricalStreamingService } from './historical-streaming';
 import { SignalKPlugin, PluginConfig, PluginState, PathConfig } from './types';
@@ -218,6 +223,27 @@ export default function (app: ServerAPI): SignalKPlugin {
     // Ensure output directory exists
     fs.ensureDirSync(state.currentConfig.outputDirectory);
 
+    // Clean up any *.tmp files left behind by a previous SignalK crash
+    // mid-COPY. Best-effort; failures are logged but do not block start.
+    await cleanupStrandedCompactionTempFiles(
+      app,
+      state.currentConfig.outputDirectory
+    ).catch(err => {
+      app.error(`Compaction startup cleanup failed: ${(err as Error).message}`);
+    });
+
+    // Recover any stranded `.compaction-trash-*` dirs from a crash
+    // between move-to-trash and publish-rename. Runs before any new
+    // data subscriptions land so a restore can't clobber fresh files.
+    await recoverStrandedCompactionTrash(
+      app,
+      state.currentConfig.outputDirectory
+    ).catch(err => {
+      app.error(
+        `Compaction trash recovery failed: ${(err as Error).message}`
+      );
+    });
+
     // Initialize DuckDB connection pool once
     await DuckDBPool.initialize();
     app.debug('DuckDB connection pool initialized');
@@ -239,8 +265,12 @@ export default function (app: ServerAPI): SignalKPlugin {
         await DuckDBPool.initializeS3({
           accessKeyId: state.currentConfig.cloudUpload.accessKeyId,
           secretAccessKey: state.currentConfig.cloudUpload.secretAccessKey,
-          region: isR2 ? 'auto' : (state.currentConfig.cloudUpload.region || 'us-east-1'),
-          endpoint: isR2 ? `${state.currentConfig.cloudUpload.accountId}.r2.cloudflarestorage.com` : undefined,
+          region: isR2
+            ? 'auto'
+            : state.currentConfig.cloudUpload.region || 'us-east-1',
+          endpoint: isR2
+            ? `${state.currentConfig.cloudUpload.accountId}.r2.cloudflarestorage.com`
+            : undefined,
         });
         app.debug('DuckDB S3 credentials initialized for federated queries');
       } catch (error) {
@@ -414,7 +444,6 @@ export default function (app: ServerAPI): SignalKPlugin {
                 }
               }
             }
-
           }
         } catch (error) {
           app.error(`[StartupExport] Failed: ${(error as Error).message}`);
@@ -469,7 +498,9 @@ export default function (app: ServerAPI): SignalKPlugin {
               enabled: true,
               bucket: state.currentConfig.cloudUpload.bucket || '',
               keyPrefix: state.currentConfig.cloudUpload.keyPrefix || '',
-              region: isR2 ? 'auto' : (state.currentConfig.cloudUpload.region || 'us-east-1'),
+              region: isR2
+                ? 'auto'
+                : state.currentConfig.cloudUpload.region || 'us-east-1',
             }
           : undefined;
 
@@ -556,6 +587,26 @@ export default function (app: ServerAPI): SignalKPlugin {
   };
 
   plugin.stop = async function (): Promise<void> {
+    // Signal any running compaction jobs to cancel and wait for them
+    // to land at a group boundary. A single in-flight DuckDB COPY is
+    // uninterruptible, so a multi-GB year group still finishes before
+    // the loop exits — but we need to wait for that, otherwise
+    // DuckDBPool.shutdown() below races the COPY and leaves a partial
+    // temp file behind. Bounded so a stuck job can't hang the stop
+    // path indefinitely.
+    const quiesce = await quiesceAllCompactionJobs();
+    if (quiesce.signalled > 0) {
+      app.debug(
+        `Compaction quiesce: signalled=${quiesce.signalled}, ` +
+          `quiesced=${quiesce.quiesced}, remaining=${quiesce.remaining}`
+      );
+      if (quiesce.remaining > 0) {
+        app.error(
+          `${quiesce.remaining} compaction job(s) still running at shutdown timeout; proceeding anyway`
+        );
+      }
+    }
+
     // Unregister as History API provider
     unregisterHistoryApiProvider(app);
 

--- a/src/services/compaction-service.ts
+++ b/src/services/compaction-service.ts
@@ -1,0 +1,923 @@
+/**
+ * Compaction Service
+ *
+ * Merges per-day parquet files within a (tier, context, path, year) group
+ * into a single per-year parquet file, then deletes the source day-files.
+ *
+ * Why: the live and import write paths emit one parquet per (path, UTC day).
+ * Over multiple years a typical vessel ends up with many thousands of small
+ * files in tier=raw, each carrying parquet's per-file overhead (schema,
+ * page index, footer). DuckDB queries spanning years pay that overhead per
+ * file, and the filesystem suffers metadata bloat.
+ *
+ * Scope: this is purely a layout transformation. Schema is preserved
+ * exactly (`SELECT *` with `union_by_name=true`), records are sorted by
+ * `signalk_timestamp`, and writes go through a temp-file + atomic-rename
+ * pattern so a partial run never corrupts the partition.
+ *
+ * After compaction the year directory contains one file like
+ *
+ *   tier=raw/context=.../path=.../year=2024/year_compact_2024_<TS>.parquet
+ *
+ * and the `day=DDD/` subdirectories under it are removed. DuckDB's
+ * hive-partitioning glob still finds the file; `day` becomes NULL for
+ * compacted years, which matters only if a downstream consumer filters by
+ * `day=…` directly. The History API filters by timestamp range, so
+ * partition pruning at the year level still works and per-file min/max
+ * stats handle the rest.
+ *
+ * Mirrors the same job-tracking / cancellable-job pattern as
+ * MigrationService, AggregationService and GpxImportService.
+ */
+
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { glob } from 'glob';
+import { ServerAPI } from '@signalk/server-api';
+import { DuckDBPool } from '../utils/duckdb-pool';
+import { HivePathBuilder, AggregationTier } from '../utils/hive-path-builder';
+import { ConcurrencyLimiter } from '../utils/concurrency-limiter';
+
+export interface CompactionConfig {
+  baseDirectory: string;
+  tier: AggregationTier;
+
+  // Year cutoff: only compact (context, path, year) groups whose year is
+  // strictly less than this. The route layer clamps this to <= current
+  // calendar year so the in-progress year never gets touched.
+  beforeYear: number;
+
+  // Optional substring filter on the SignalK path (e.g. 'navigation.').
+  pathFilter?: string;
+}
+
+export interface CompactionPlanGroup {
+  tier: string;
+  context: string;
+  path: string;
+  year: number;
+  yearDir: string;
+  // Source files captured at scan time. Reused at compact time to avoid
+  // a second glob and to give the plan a stable shape.
+  sourcePaths: string[];
+  sourceFiles: number;
+  sourceBytes: number;
+}
+
+export interface CompactionPlan {
+  totalGroups: number;
+  totalSourceFiles: number;
+  totalSourceBytes: number;
+  groups: CompactionPlanGroup[];
+}
+
+export interface CompactionProgress {
+  jobId: string;
+  status: 'scanning' | 'running' | 'completed' | 'cancelled' | 'error';
+  phase: 'scan' | 'compact';
+  processed: number;
+  total: number;
+  percent: number;
+  currentGroup?: string;
+  startTime: Date;
+  completedAt?: Date;
+  error?: string;
+  groupsCompacted: number;
+  groupsSkipped: number;
+  filesRemoved: number;
+  bytesBefore: number;
+  bytesAfter: number;
+  errors: string[];
+}
+
+const COMPACTION_OUTPUT_PREFIX = 'year_compact';
+const COMPACTION_TEMP_SUFFIX = '.tmp';
+// Sources are moved here (atomic renames within yearDir) before the
+// new yearly file is published, so queries never see both at once.
+// Cleared after the publish rename succeeds; restored on rollback.
+const COMPACTION_TRASH_PREFIX = '.compaction-trash-';
+
+// An empty parquet file (magic bytes + footer + schema) lands a few hundred
+// bytes; anything visibly smaller than this means the writer produced
+// nothing useful and we must not delete the sources.
+const MIN_PLAUSIBLE_PARQUET_BYTES = 200;
+
+const COMPACTION_JOB_TTL_MS = 60 * 60 * 1000; // 1 hour
+const RENAME_RETRY_DELAY_MS = 200;
+
+// Per-source delete retry: covers Windows transients (antivirus,
+// search indexer, file explorer) holding a brief handle on the file.
+// Exponential-ish backoff: 100ms, 200ms, 400ms, 800ms, 1600ms.
+const SOURCE_DELETE_MAX_ATTEMPTS = 5;
+const SOURCE_DELETE_BASE_DELAY_MS = 100;
+
+// Cap parallel filesystem ops during scan so a multi-year tree with
+// thousands of (context, path, year) groups doesn't fan out into an
+// EMFILE storm or starve other plugin work.
+const SCAN_CONCURRENCY = 8;
+
+// Module-level so plugin.stop() can signal cancellation across any live
+// CompactionService instance without needing a registry.
+const compactionJobs = new Map<string, CompactionProgress>();
+const cancelledJobIds: Set<string> = new Set();
+
+/**
+ * True if any compaction job is currently scanning or running. Used to
+ * serialize jobs at the start endpoint: two concurrent runs could pick
+ * up the same (tier, context, path, year) and merge it twice into
+ * separate `year_compact_*.parquet` files, making duplicate rows
+ * query-visible.
+ */
+function isAnyCompactionActive(): boolean {
+  for (const job of compactionJobs.values()) {
+    if (job.status === 'scanning' || job.status === 'running') return true;
+  }
+  return false;
+}
+
+export class CompactionConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CompactionConflictError';
+  }
+}
+
+/**
+ * True if the given parquet file is a compaction output (i.e. the
+ * result of a previous run for this year-dir). Used both at scan time
+ * to skip already-compacted year-dirs and at compact time as a
+ * defense-in-depth check before merging.
+ */
+function isCompactionOutput(parquetPath: string): boolean {
+  return path.basename(parquetPath).startsWith(`${COMPACTION_OUTPUT_PREFIX}_`);
+}
+
+function scheduleJobCleanup(jobId: string) {
+  setTimeout(() => {
+    const job = compactionJobs.get(jobId);
+    if (job && job.status !== 'running' && job.status !== 'scanning') {
+      compactionJobs.delete(jobId);
+      cancelledJobIds.delete(jobId);
+    }
+  }, COMPACTION_JOB_TTL_MS);
+}
+
+/**
+ * Mark every running/scanning compaction job for cancellation. Called
+ * from plugin.stop() so a SignalK shutdown does not leave a job spinning
+ * past the next group boundary. Does not await: a single in-flight
+ * DuckDB COPY is uninterruptible, but the per-group loop will exit on
+ * the next iteration check.
+ */
+export function signalShutdownAllCompactionJobs(): number {
+  let signalled = 0;
+  for (const [jobId, job] of compactionJobs) {
+    if (job.status === 'running' || job.status === 'scanning') {
+      cancelledJobIds.add(jobId);
+      signalled++;
+    }
+  }
+  return signalled;
+}
+
+function countActiveCompactionJobs(): number {
+  let active = 0;
+  for (const job of compactionJobs.values()) {
+    if (job.status === 'scanning' || job.status === 'running') active++;
+  }
+  return active;
+}
+
+/**
+ * Signal cancellation to every active job and wait for them to reach a
+ * terminal state, bounded by `timeoutMs`. Use this from plugin.stop()
+ * so DuckDBPool.shutdown() doesn't run while a COPY is still in flight
+ * — that race turns a clean stop into a failed compaction at best, or
+ * a partial temp file at worst.
+ *
+ * Returns counts so the caller can log what happened. `remaining > 0`
+ * means a job was still running at timeout; the plugin proceeds with
+ * shutdown anyway, since blocking forever is worse than leaking a job.
+ */
+export async function quiesceAllCompactionJobs(
+  timeoutMs = 30_000
+): Promise<{ signalled: number; quiesced: number; remaining: number }> {
+  const signalled = signalShutdownAllCompactionJobs();
+  if (signalled === 0) return { signalled: 0, quiesced: 0, remaining: 0 };
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const remaining = countActiveCompactionJobs();
+    if (remaining === 0) {
+      return { signalled, quiesced: signalled, remaining: 0 };
+    }
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+
+  const remaining = countActiveCompactionJobs();
+  return { signalled, quiesced: signalled - remaining, remaining };
+}
+
+/**
+ * Remove stranded `*.tmp` files left behind by a SignalK crash mid-COPY.
+ * Safe to call at every plugin start: only files matching the compaction
+ * temp pattern under the data directory are removed.
+ */
+export async function cleanupStrandedCompactionTempFiles(
+  app: ServerAPI,
+  baseDirectory: string
+): Promise<{ removed: number }> {
+  if (!(await fs.pathExists(baseDirectory))) return { removed: 0 };
+  const pattern = path.join(
+    baseDirectory,
+    'tier=*',
+    'context=*',
+    'path=*',
+    'year=*',
+    `${COMPACTION_OUTPUT_PREFIX}_*${COMPACTION_TEMP_SUFFIX}`
+  );
+  const stragglers = await glob(pattern);
+  let removed = 0;
+  for (const f of stragglers) {
+    try {
+      await fs.remove(f);
+      removed++;
+      app.debug(`Removed stranded compaction temp file: ${f}`);
+    } catch (err) {
+      app.error(
+        `Failed to remove stranded compaction temp file ${f}: ${(err as Error).message}`
+      );
+    }
+  }
+  if (removed > 0) {
+    app.debug(
+      `Compaction startup cleanup: removed ${removed} stranded *.tmp file(s)`
+    );
+  }
+  return { removed };
+}
+
+/**
+ * Recover from stale `.compaction-trash-*` directories left by a crash
+ * between move-to-trash and rename-to-published. Two cases:
+ *
+ *   - Yearly file present in the parent: the publish completed before
+ *     the crash; trash holds duplicate sources that the post-publish
+ *     cleanup never got to remove. Delete the trash dir.
+ *   - Yearly file absent: the crash happened mid-move (or after move
+ *     but before publish). Restore the trashed files back to their
+ *     mirrored locations under the year-dir, then delete the empty
+ *     trash dir.
+ *
+ * This runs early in plugin start, before any new data writes can land
+ * in day-dirs, so a restore can't clobber anything.
+ */
+export async function recoverStrandedCompactionTrash(
+  app: ServerAPI,
+  baseDirectory: string
+): Promise<{ restored: number; cleaned: number; failed: number }> {
+  if (!(await fs.pathExists(baseDirectory))) {
+    return { restored: 0, cleaned: 0, failed: 0 };
+  }
+  const pattern = path.join(
+    baseDirectory,
+    'tier=*',
+    'context=*',
+    'path=*',
+    'year=*',
+    `${COMPACTION_TRASH_PREFIX}*`
+  );
+  const trashDirs = await glob(pattern);
+
+  let restored = 0;
+  let cleaned = 0;
+  let failed = 0;
+
+  for (const trashDir of trashDirs) {
+    const yearDir = path.dirname(trashDir);
+    const compactedSiblings = await glob(
+      path.join(yearDir, `${COMPACTION_OUTPUT_PREFIX}_*.parquet`)
+    );
+
+    if (compactedSiblings.length > 0) {
+      // Publish completed; trash is post-publish residue.
+      try {
+        await fs.remove(trashDir);
+        cleaned++;
+        app.debug(`Removed post-publish compaction trash: ${trashDir}`);
+      } catch (err) {
+        failed++;
+        app.error(
+          `Failed to remove compaction trash ${trashDir}: ${(err as Error).message}`
+        );
+      }
+      continue;
+    }
+
+    // Pre-publish trash: restore by mirroring back to yearDir.
+    try {
+      const trashedFiles = await glob(path.join(trashDir, '**', '*.parquet'));
+      for (const trashed of trashedFiles) {
+        const relative = path.relative(trashDir, trashed);
+        const original = path.join(yearDir, relative);
+        await fs.ensureDir(path.dirname(original));
+        await fs.rename(trashed, original);
+      }
+      await fs.remove(trashDir);
+      restored++;
+      app.debug(
+        `Restored ${trashedFiles.length} pre-publish compaction file(s) from ${trashDir}`
+      );
+    } catch (err) {
+      failed++;
+      app.error(
+        `Failed to restore compaction trash ${trashDir}: ${(err as Error).message}`
+      );
+    }
+  }
+
+  if (restored + cleaned + failed > 0) {
+    app.debug(
+      `Compaction trash recovery: restored=${restored}, cleaned=${cleaned}, failed=${failed}`
+    );
+  }
+  return { restored, cleaned, failed };
+}
+
+export class CompactionService {
+  private readonly app: ServerAPI;
+  private readonly hivePathBuilder: HivePathBuilder;
+
+  constructor(app: ServerAPI) {
+    this.app = app;
+    this.hivePathBuilder = new HivePathBuilder();
+  }
+
+  /**
+   * Walk the Hive layout for a given tier and return what would be
+   * compacted. Groups with only one file are not included (already
+   * compact). Non-destructive — safe to call repeatedly.
+   */
+  async scan(config: CompactionConfig): Promise<CompactionPlan> {
+    const groups = await this.findCompactableGroups(config);
+    return {
+      totalGroups: groups.length,
+      totalSourceFiles: groups.reduce((s, g) => s + g.sourceFiles, 0),
+      totalSourceBytes: groups.reduce((s, g) => s + g.sourceBytes, 0),
+      groups,
+    };
+  }
+
+  async compact(config: CompactionConfig): Promise<string> {
+    // Refuse to start a second job while one is already scanning or
+    // running. Two concurrent jobs against overlapping config can both
+    // pick up the same year-dir, write separate compaction outputs,
+    // and double the rows for that group.
+    if (isAnyCompactionActive()) {
+      throw new CompactionConflictError(
+        'Another compaction job is already running. Wait for it to finish or cancel it first.'
+      );
+    }
+
+    const jobId = `compact_${Date.now()}_${Math.random().toString(36).substring(2, 8)}`;
+
+    const progress: CompactionProgress = {
+      jobId,
+      status: 'scanning',
+      phase: 'scan',
+      processed: 0,
+      total: 0,
+      percent: 0,
+      startTime: new Date(),
+      groupsCompacted: 0,
+      groupsSkipped: 0,
+      filesRemoved: 0,
+      bytesBefore: 0,
+      bytesAfter: 0,
+      errors: [],
+    };
+
+    compactionJobs.set(jobId, progress);
+
+    this.app.debug(
+      `Compaction job ${jobId} starting: tier=${config.tier}, beforeYear=${config.beforeYear}` +
+        (config.pathFilter ? `, pathFilter='${config.pathFilter}'` : '')
+    );
+
+    this.run(jobId, config)
+      .catch(error => {
+        const job = compactionJobs.get(jobId);
+        if (job) {
+          job.status = 'error';
+          job.error = (error as Error).message;
+          job.completedAt = new Date();
+        }
+        this.app.error(
+          `Compaction job ${jobId} failed: ${(error as Error).message}`
+        );
+      })
+      .finally(() => {
+        cancelledJobIds.delete(jobId);
+        const job = compactionJobs.get(jobId);
+        if (job && job.status === 'completed') {
+          this.app.debug(
+            `Compaction job ${jobId} completed: ` +
+              `groupsCompacted=${job.groupsCompacted}, ` +
+              `groupsSkipped=${job.groupsSkipped}, ` +
+              `filesRemoved=${job.filesRemoved}, ` +
+              `bytesBefore=${job.bytesBefore}, ` +
+              `bytesAfter=${job.bytesAfter}, ` +
+              `errors=${job.errors.length}`
+          );
+        }
+      });
+
+    return jobId;
+  }
+
+  private async run(jobId: string, config: CompactionConfig): Promise<void> {
+    const progress = compactionJobs.get(jobId);
+    if (!progress) return;
+
+    try {
+      progress.phase = 'scan';
+      progress.status = 'scanning';
+
+      const groups = await this.findCompactableGroups(config);
+      progress.total = groups.length;
+
+      if (groups.length === 0) {
+        progress.status = 'completed';
+        progress.completedAt = new Date();
+        scheduleJobCleanup(jobId);
+        return;
+      }
+
+      progress.phase = 'compact';
+      progress.status = 'running';
+
+      for (let i = 0; i < groups.length; i++) {
+        if (cancelledJobIds.has(jobId)) {
+          progress.status = 'cancelled';
+          progress.completedAt = new Date();
+          this.app.debug(
+            `Compaction job ${jobId} cancelled after ${i}/${groups.length} groups`
+          );
+          scheduleJobCleanup(jobId);
+          return;
+        }
+
+        const group = groups[i];
+        progress.currentGroup = `${group.tier} ${group.context} ${group.path} year=${group.year}`;
+        progress.processed = i + 1;
+        progress.percent = Math.round(((i + 1) / groups.length) * 100);
+
+        try {
+          const result = await this.compactGroup(group, jobId);
+          if (result.compacted) {
+            progress.groupsCompacted++;
+            progress.bytesBefore += group.sourceBytes;
+            progress.bytesAfter += result.outputBytes;
+            progress.filesRemoved += result.filesRemoved;
+            for (const residual of result.residualSources) {
+              progress.errors.push(
+                `Residual source after compaction: ${residual} (could not be deleted)`
+              );
+            }
+          } else {
+            progress.groupsSkipped++;
+          }
+        } catch (error) {
+          const errorMsg = `Failed to compact ${progress.currentGroup}: ${(error as Error).message}`;
+          this.app.error(errorMsg);
+          progress.errors.push(errorMsg);
+        }
+      }
+
+      progress.status = 'completed';
+      progress.completedAt = new Date();
+      scheduleJobCleanup(jobId);
+    } catch (error) {
+      progress.status = 'error';
+      progress.error = (error as Error).message;
+      progress.completedAt = new Date();
+      scheduleJobCleanup(jobId);
+    }
+  }
+
+  /**
+   * Walk the Hive layout tier=<T>/context=.../path=.../year=... and
+   * return one group per year-directory that has more than one parquet
+   * file under it.
+   *
+   * Scale note: result size is O(#contexts × #paths × #years). On a
+   * typical SignalK install (one vessel, ~hundreds of paths, single-digit
+   * years) this fits comfortably in memory.
+   */
+  private async findCompactableGroups(
+    config: CompactionConfig
+  ): Promise<CompactionPlanGroup[]> {
+    const tierRoot = path.join(config.baseDirectory, `tier=${config.tier}`);
+    if (!(await fs.pathExists(tierRoot))) {
+      return [];
+    }
+
+    const yearDirs = await glob(
+      path.join(tierRoot, 'context=*', 'path=*', 'year=*')
+    );
+
+    // Stat each year directory; filter to actual directories matching
+    // the cutoff and the optional path substring filter. Capped at
+    // SCAN_CONCURRENCY to avoid EMFILE on large trees.
+    const limiter = new ConcurrencyLimiter(SCAN_CONCURRENCY);
+    const candidates = await limiter.map(yearDirs, async yearDir => {
+      const stat = await fs.stat(yearDir).catch(() => null);
+      if (!stat || !stat.isDirectory()) return null;
+      const parsed = this.parseYearDir(yearDir);
+      if (!parsed) return null;
+      if (parsed.year >= config.beforeYear) return null;
+      if (config.pathFilter && !parsed.path.includes(config.pathFilter)) {
+        return null;
+      }
+      return { yearDir, parsed };
+    });
+
+    // For each surviving candidate, list its day-partition parquet
+    // files and sum bytes. The glob is intentionally narrow:
+    // `day=*/*.parquet` only picks up live day partitions, so siblings
+    // like `year_compact_*.parquet`, `repaired/`, `quarantine/` etc.
+    // never enter the source list. Year-dirs that already contain a
+    // compaction-output file (top-level sibling) are skipped entirely
+    // — re-merging them would duplicate rows that already live in the
+    // compacted output (the previous run wrote one and then either
+    // succeeded entirely or left residual sources behind; either way,
+    // no rewrite is safe without manual cleanup).
+    const groupResults = await limiter.map(
+      candidates.filter(
+        (
+          c
+        ): c is {
+          yearDir: string;
+          parsed: NonNullable<ReturnType<CompactionService['parseYearDir']>>;
+        } => c !== null
+      ),
+      async ({ yearDir, parsed }) => {
+        const existing = await glob(
+          path.join(yearDir, `${COMPACTION_OUTPUT_PREFIX}_*.parquet`)
+        );
+        if (existing.length > 0) return null;
+        const parquetFiles = await glob(
+          path.join(yearDir, 'day=*', '*.parquet')
+        );
+        if (parquetFiles.length <= 1) return null;
+        const sizes = await limiter.map(parquetFiles, f =>
+          fs
+            .stat(f)
+            .then(s => s.size)
+            .catch(() => 0)
+        );
+        const sourceBytes = sizes.reduce((s, n) => s + n, 0);
+        const group: CompactionPlanGroup = {
+          tier: config.tier,
+          context: parsed.context,
+          path: parsed.path,
+          year: parsed.year,
+          yearDir,
+          sourcePaths: parquetFiles,
+          sourceFiles: parquetFiles.length,
+          sourceBytes,
+        };
+        return group;
+      }
+    );
+
+    const groups = groupResults.filter(
+      (g): g is CompactionPlanGroup => g !== null
+    );
+
+    // Stable order: oldest year first, then alphabetical. Predictable
+    // progress + a cancelled job leaves a clean tail of unprocessed groups.
+    groups.sort(
+      (a, b) =>
+        a.year - b.year ||
+        a.context.localeCompare(b.context) ||
+        a.path.localeCompare(b.path)
+    );
+
+    return groups;
+  }
+
+  /**
+   * Parse the trailing four segments of a Hive year directory into the
+   * tier/context/path/year tuple. Returns null on shape mismatch.
+   *
+   * Example input:  "/data/tier=raw/context=vessels__urn-mrn-…/path=navigation__position/year=2024"
+   * Example output: { context: "vessels.urn:mrn:…", path: "navigation.position", year: 2024 }
+   */
+  private parseYearDir(
+    yearDir: string
+  ): { context: string; path: string; year: number } | null {
+    const parts = yearDir.split(/[\\/]/);
+    const yearSeg = parts[parts.length - 1];
+    const pathSeg = parts[parts.length - 2];
+    const ctxSeg = parts[parts.length - 3];
+
+    if (
+      !yearSeg?.startsWith('year=') ||
+      !pathSeg?.startsWith('path=') ||
+      !ctxSeg?.startsWith('context=')
+    ) {
+      return null;
+    }
+
+    const year = parseInt(yearSeg.slice('year='.length), 10);
+    if (!Number.isFinite(year)) return null;
+
+    return {
+      context: this.hivePathBuilder.unsanitizeContext(
+        ctxSeg.slice('context='.length)
+      ),
+      path: this.hivePathBuilder.unsanitizePath(pathSeg.slice('path='.length)),
+      year,
+    };
+  }
+
+  /**
+   * Merge all parquet files under one (tier, context, path, year) group
+   * into a single output file, then remove the sources.
+   *
+   * Publish sequence (atomic from a reader's perspective):
+   *   1. DuckDB COPY into `<output>.tmp`, size-checked.
+   *   2. Source files are *moved* (rename within yearDir) into a trash
+   *      directory: `<yearDir>/.compaction-trash-<jobId>/`. Mirrors the
+   *      original day=DDD/ structure so rollback is just a reverse
+   *      rename.
+   *   3. The temp file is renamed to its final `year_compact_*.parquet`
+   *      name. This is the publish point.
+   *   4. The trash directory is recursively removed.
+   *
+   * Why moves first, then publish: between steps 3 and 4 in a
+   * "publish-then-delete" scheme, queries see both the new yearly file
+   * and every still-present source — duplicate rows on the wire. The
+   * trash-first scheme makes the year-dir's queryable contents flip
+   * atomically: before the publish rename a query sees the originals
+   * (less any briefly-renamed files mid-step-2), after it the query
+   * sees only the yearly file.
+   *
+   * Failure handling:
+   *   - Step 1/2 failure (pre-publish): reverse any moves that did
+   *     succeed, delete temp, delete trash dir. Sources end back where
+   *     they started; no data lost. The group surfaces an error.
+   *   - Step 3 failure: same rollback as above.
+   *   - Step 4 failure (post-publish): data is committed; the yearly
+   *     file holds everything. Failure to clean trash is logged and
+   *     surfaced via `residualSources` (now meaning "files left in
+   *     trash that the operator may want to remove"). Startup sweep
+   *     handles these on next plugin start.
+   */
+  private async compactGroup(
+    group: CompactionPlanGroup,
+    jobId: string
+  ): Promise<{
+    compacted: boolean;
+    outputBytes: number;
+    filesRemoved: number;
+    residualSources: string[];
+  }> {
+    const sourceFiles = group.sourcePaths;
+    if (sourceFiles.length <= 1) {
+      return {
+        compacted: false,
+        outputBytes: 0,
+        filesRemoved: 0,
+        residualSources: [],
+      };
+    }
+
+    // Defense in depth: scan-time filtering is supposed to exclude
+    // year-dirs that already hold a compaction output, but a stale
+    // plan or hand-edited input could still get here. Refuse rather
+    // than re-merge and duplicate rows.
+    if (sourceFiles.some(isCompactionOutput)) {
+      throw new Error(
+        `Refusing to compact ${group.yearDir}: a previous compaction output is present. Remove it manually before re-running.`
+      );
+    }
+
+    // Filenames in our layout are ASCII (UUID + timestamp + path-derived
+    // basename). Refuse to proceed if any filename — source or
+    // destination — contains a single quote, since we splice them into
+    // a SQL string literal below.
+    const stamp = formatCompactionStamp(new Date());
+    const randomSuffix = Math.random().toString(36).substring(2, 6);
+    const outputFile = path.join(
+      group.yearDir,
+      `${COMPACTION_OUTPUT_PREFIX}_${group.year}_${stamp}_${randomSuffix}.parquet`
+    );
+    const tempFile = outputFile + COMPACTION_TEMP_SUFFIX;
+
+    // Forward slashes in SQL paths so DuckDB on Windows is happy. Single
+    // quotes in path components are doubled for the SQL string-literal
+    // form, so an apostrophe in `outputDirectory` (or any parent dir)
+    // doesn't fail compaction outright.
+    const toSqlLiteralBody = (p: string): string =>
+      p.split(path.sep).join('/').replace(/'/g, "''");
+    const fileListSql = sourceFiles
+      .map(f => `'${toSqlLiteralBody(f)}'`)
+      .join(', ');
+    const tempFileSql = toSqlLiteralBody(tempFile);
+
+    // union_by_name=true: a column added partway through the year (e.g.
+    // a new value_<key> exploded from value_json) merges cleanly. The
+    // result has the union of columns; older rows have NULL where the
+    // newer column is absent. Snappy compression matches the existing
+    // consolidate-parquet.sh convention.
+    const query = `
+      COPY (
+        SELECT * FROM read_parquet([${fileListSql}], union_by_name=true)
+        ORDER BY signalk_timestamp
+      ) TO '${tempFileSql}'
+        (FORMAT PARQUET, COMPRESSION SNAPPY);
+    `;
+
+    const connection = await DuckDBPool.getConnection();
+    try {
+      await connection.runAndReadAll(query);
+    } finally {
+      connection.disconnectSync();
+    }
+
+    // Guard against a broken-but-present temp file. The size guard is
+    // the load-bearing check; we deliberately do not assume DuckDB will
+    // throw on an empty COPY since that contract is undocumented.
+    const stat = await fs.stat(tempFile);
+    if (stat.size < MIN_PLAUSIBLE_PARQUET_BYTES) {
+      await fs.remove(tempFile).catch(err => {
+        this.app.error(
+          `Failed to remove undersized temp file ${tempFile}: ${(err as Error).message}`
+        );
+      });
+      throw new Error(
+        `Compaction produced an implausibly small file (${stat.size} bytes); leaving sources untouched.`
+      );
+    }
+
+    // Step 2: move sources into the trash dir (mirroring day=DDD/
+    // structure) and step 3: publish-rename. Wrapped in try/catch so
+    // any failure rolls the moves back and leaves the year-dir
+    // exactly as we found it.
+    const trashDir = path.join(
+      group.yearDir,
+      `${COMPACTION_TRASH_PREFIX}${jobId}`
+    );
+    const completedMoves: Array<{ from: string; to: string }> = [];
+    try {
+      await fs.ensureDir(trashDir);
+      for (const f of sourceFiles) {
+        if (f === outputFile) continue;
+        const relative = path.relative(group.yearDir, f);
+        const trashed = path.join(trashDir, relative);
+        await fs.ensureDir(path.dirname(trashed));
+        await fs.rename(f, trashed);
+        completedMoves.push({ from: f, to: trashed });
+      }
+      await this.renameWithRetry(tempFile, outputFile);
+    } catch (err) {
+      // Reverse moves so callers see the year-dir untouched.
+      for (const m of completedMoves.reverse()) {
+        try {
+          await fs.ensureDir(path.dirname(m.from));
+          await fs.rename(m.to, m.from);
+        } catch (restoreErr) {
+          this.app.error(
+            `Compaction rollback: failed to restore ${m.to} -> ${m.from}: ${(restoreErr as Error).message}`
+          );
+        }
+      }
+      await fs.remove(tempFile).catch(() => undefined);
+      await fs.remove(trashDir).catch(() => undefined);
+      throw err;
+    }
+
+    // Step 4: post-publish cleanup. Data is committed; failures here
+    // are logged and surfaced as residuals but don't fail the group.
+    const movedCount = completedMoves.length;
+    const residualSources: string[] = [];
+    let removed = movedCount;
+    try {
+      await this.removeWithRetry(trashDir);
+    } catch (err) {
+      this.app.error(
+        `Failed to remove compaction trash dir ${trashDir} (${SOURCE_DELETE_MAX_ATTEMPTS} attempts): ${(err as Error).message}`
+      );
+      residualSources.push(trashDir);
+      removed = 0;
+    }
+
+    await this.removeEmptyDayDirs(group.yearDir);
+
+    return {
+      compacted: true,
+      outputBytes: stat.size,
+      filesRemoved: removed,
+      residualSources,
+    };
+  }
+
+  /**
+   * Rename with one retry on EBUSY. On Windows a reader (DuckDB query,
+   * antivirus, file explorer preview) can briefly hold the destination
+   * path; a single backoff-and-retry covers the common case without
+   * making us wait indefinitely.
+   */
+  private async renameWithRetry(
+    tempFile: string,
+    outputFile: string
+  ): Promise<void> {
+    try {
+      await fs.rename(tempFile, outputFile);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'EBUSY' && code !== 'EPERM') throw err;
+      this.app.debug(
+        `rename(${tempFile} -> ${outputFile}) failed with ${code}, retrying once`
+      );
+      await new Promise(resolve => setTimeout(resolve, RENAME_RETRY_DELAY_MS));
+      await fs.rename(tempFile, outputFile);
+    }
+  }
+
+  /**
+   * Remove a file or directory with exponential backoff on transient
+   * errors. Windows readers (antivirus, search indexer, explorer
+   * preview) can hold a brief handle; one delete attempt isn't enough.
+   * After all attempts the last error is rethrown so the caller can
+   * record it (e.g. as a residual). Permanent errors (ENOENT, etc.)
+   * are not retried.
+   */
+  private async removeWithRetry(target: string): Promise<void> {
+    let lastErr: unknown;
+    for (let attempt = 0; attempt < SOURCE_DELETE_MAX_ATTEMPTS; attempt++) {
+      try {
+        await fs.remove(target);
+        return;
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === 'ENOENT') return;
+        if (code !== 'EBUSY' && code !== 'EPERM') throw err;
+        lastErr = err;
+        if (attempt < SOURCE_DELETE_MAX_ATTEMPTS - 1) {
+          const delay = SOURCE_DELETE_BASE_DELAY_MS * 2 ** attempt;
+          await new Promise(resolve => setTimeout(resolve, delay));
+        }
+      }
+    }
+    throw lastErr;
+  }
+
+  private async removeEmptyDayDirs(yearDir: string): Promise<void> {
+    const entries = await fs.readdir(yearDir).catch(() => []);
+    for (const entry of entries) {
+      if (!entry.startsWith('day=')) continue;
+      const dayDir = path.join(yearDir, entry);
+      const dayEntries = await fs.readdir(dayDir).catch(() => []);
+      if (dayEntries.length === 0) {
+        await fs.remove(dayDir).catch(err => {
+          this.app.debug(
+            `Failed to remove empty day dir ${dayDir}: ${(err as Error).message}`
+          );
+        });
+      }
+    }
+  }
+
+  getProgress(jobId: string): CompactionProgress | null {
+    return compactionJobs.get(jobId) || null;
+  }
+
+  cancel(jobId: string): boolean {
+    const job = compactionJobs.get(jobId);
+    if (job && (job.status === 'running' || job.status === 'scanning')) {
+      cancelledJobIds.add(jobId);
+      return true;
+    }
+    return false;
+  }
+
+  getJobIds(): string[] {
+    return Array.from(compactionJobs.keys());
+  }
+}
+
+/**
+ * Format the timestamp suffix for compacted-file basenames as
+ * `YYYYMMDDTHHMMSS` (UTC). Explicit format to avoid the silent
+ * truncation that comes from slicing toISOString().
+ */
+function formatCompactionStamp(d: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return (
+    `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}` +
+    `T${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}`
+  );
+}

--- a/tests/rest-api-tests.sh
+++ b/tests/rest-api-tests.sh
@@ -498,6 +498,103 @@ else
 fi
 
 # ============================================================
+# K. COMPACTION ENDPOINTS
+# ============================================================
+log_section "K. Compaction Endpoints"
+
+# K1: Scan with default args (read-only; safe on any store)
+log_test "K1: Compact scan (tier=raw)"
+RESPONSE=$(auth_request POST "/plugins/signalk-parquet/api/compact/scan" \
+    '{"tier": "raw"}')
+check_response "$RESPONSE" "K1: Compact scan" "totalGroups"
+
+# K2: Scan with invalid tier (expect 400-style error in body)
+log_test "K2: Compact scan with invalid tier"
+RESPONSE=$(auth_request POST "/plugins/signalk-parquet/api/compact/scan" \
+    '{"tier": "bogus"}')
+if echo "$RESPONSE" | jq -e '.error' > /dev/null 2>&1; then
+    log_pass "K2: Invalid tier rejected"
+else
+    log_fail "K2: Invalid tier" "Expected error, got: $RESPONSE"
+fi
+
+# K3: Scan with out-of-range beforeYear (expect error)
+log_test "K3: Compact scan with invalid beforeYear"
+RESPONSE=$(auth_request POST "/plugins/signalk-parquet/api/compact/scan" \
+    '{"tier": "raw", "beforeYear": 1900}')
+if echo "$RESPONSE" | jq -e '.error' > /dev/null 2>&1; then
+    log_pass "K3: Invalid beforeYear rejected"
+else
+    log_fail "K3: Invalid beforeYear" "Expected error, got: $RESPONSE"
+fi
+
+# K4: Start compaction; capture jobId for follow-ups. The store may
+# have nothing to compact, in which case the job completes near-instantly
+# but jobId is still returned.
+log_test "K4: Start compaction"
+COMPACT_START=$(auth_request POST "/plugins/signalk-parquet/api/compact" \
+    '{"tier": "raw"}')
+COMPACT_JOB_ID=$(echo "$COMPACT_START" | jq -r '.jobId // empty')
+if [[ -n "$COMPACT_JOB_ID" ]]; then
+    log_pass "K4: Compaction started (jobId=${COMPACT_JOB_ID:0:8}...)"
+else
+    log_fail "K4: Compaction start" "No jobId in: $COMPACT_START"
+fi
+
+# K5: Poll progress for the started job
+if [[ -n "$COMPACT_JOB_ID" ]]; then
+    log_test "K5: Compact progress for live job"
+    RESPONSE=$(auth_request GET "/plugins/signalk-parquet/api/compact/progress/${COMPACT_JOB_ID}")
+    check_response "$RESPONSE" "K5: Compact progress" "status"
+else
+    log_skip "K5: Compact progress (no jobId from K4)"
+fi
+
+# K6: List active/recent jobs
+log_test "K6: List compaction jobs"
+RESPONSE=$(auth_request GET "/plugins/signalk-parquet/api/compact/jobs")
+check_response "$RESPONSE" "K6: List jobs" "jobs"
+
+# K7: Cancel the started job. With no work to do, the job may already
+# be 'completed' by the time we cancel; either response is acceptable.
+if [[ -n "$COMPACT_JOB_ID" ]]; then
+    log_test "K7: Cancel compaction job"
+    RESPONSE=$(auth_request POST "/plugins/signalk-parquet/api/compact/cancel/${COMPACT_JOB_ID}" '{}')
+    if echo "$RESPONSE" | jq -e '.success' > /dev/null 2>&1; then
+        log_pass "K7: Cancel accepted"
+    elif echo "$RESPONSE" | jq -e '.error' > /dev/null 2>&1; then
+        ERROR_MSG=$(echo "$RESPONSE" | jq -r '.error')
+        if [[ "$ERROR_MSG" == *"not running"* ]] || [[ "$ERROR_MSG" == *"not found"* ]]; then
+            log_pass "K7: Cancel of finished/unknown job (job already completed)"
+        else
+            log_fail "K7: Cancel" "$ERROR_MSG"
+        fi
+    else
+        log_fail "K7: Cancel" "Unexpected: $RESPONSE"
+    fi
+else
+    log_skip "K7: Cancel (no jobId from K4)"
+fi
+
+# K8: Progress for an unknown job (expect 404-style error)
+log_test "K8: Progress for unknown job"
+RESPONSE=$(auth_request GET "/plugins/signalk-parquet/api/compact/progress/nonexistent-job-id")
+if echo "$RESPONSE" | jq -e '.error' > /dev/null 2>&1; then
+    log_pass "K8: Unknown jobId rejected"
+else
+    log_fail "K8: Unknown jobId" "Expected error, got: $RESPONSE"
+fi
+
+# K9: Cancel of unknown job (expect error)
+log_test "K9: Cancel unknown job"
+RESPONSE=$(auth_request POST "/plugins/signalk-parquet/api/compact/cancel/nonexistent-job-id" '{}')
+if echo "$RESPONSE" | jq -e '.error' > /dev/null 2>&1; then
+    log_pass "K9: Unknown jobId cancel rejected"
+else
+    log_fail "K9: Unknown jobId cancel" "Expected error, got: $RESPONSE"
+fi
+
+# ============================================================
 # SUMMARY
 # ============================================================
 log_section "TEST SUMMARY"


### PR DESCRIPTION
Follow-up to #51. Adds a per-year compaction pipeline so long-running stores stay queryable.

The live and import write paths emit one parquet per (path, UTC day). Over multiple years that becomes many thousands of small files in `tier=raw`, each carrying parquet's per-file overhead. DuckDB queries spanning years pay that overhead per file, and the filesystem suffers metadata bloat.

This PR introduces a `CompactionService` that merges all parquet files under each `(tier, context, path, year)` group into a single per-year file via DuckDB:

```sql
COPY (
  SELECT * FROM read_parquet([<files>], union_by_name=true)
  ORDER BY signalk_timestamp
) TO '<temp>' (FORMAT PARQUET, COMPRESSION SNAPPY);
```

Same Snappy + `union_by_name` convention as the existing `scripts/consolidate-parquet.sh`. Atomic `.tmp` → rename; source files are only deleted after the new file is in place; empty `day=DDD/` subdirectories are pruned afterwards. Per-job cancellation via `Set<string>` so concurrent runs don't trample each other.

**API**
- `POST /api/compact/scan` — preview groups, file counts and total source size
- `POST /api/compact` — start a job
- `GET /api/compact/progress/:jobId`
- `POST /api/compact/cancel/:jobId`
- `GET /api/compact/jobs`

Body fields: `tier` (default `raw`), `beforeYear` (default current calendar year — never touches the in-progress year), optional `pathFilter` substring.

**Admin UI**
A new "Compact old years" panel in the Status tab with tier select, optional `beforeYear` override, optional path filter, scan + start + cancel buttons, and a progress panel that reports groups compacted / source files removed / before-vs-after size.

**Layout note**

Compacted files live alongside whatever `day=DDD/` subdirectories remain (usually only the current year). DuckDB's hive-partitioning glob still finds them; the `day` partition column becomes `NULL` for compacted years. Queries that filter by timestamp range — what the History API does — still get year-level partition pruning plus per-file min/max stats, so query performance improves rather than regresses.

## Test plan

- [x] `npm run build` clean.
- [ ] On a populated store: `/api/compact/scan tier=raw` returns the expected per-year groups.
- [ ] `/api/compact tier=raw` produces one file per group, removes source day-files, leaves day-dirs empty (and removed).
- [ ] DuckDB `read_parquet('.../tier=raw/**/*.parquet', hive_partitioning=true)` reads compacted + non-compacted years uniformly.
- [ ] Cancel mid-run: in-progress group either completes or rolls back via the `.tmp` rename guard; sources for not-yet-started groups untouched.
- [ ] Idempotent: re-running scan after a successful compaction returns 0 groups (only-one-file rule).