### PR TITLE
feat: per-path retention overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [0.7.40-beta.1] - 2026-05-01
 
+### Breaking
+
+- **`retentionDays` is now actively enforced.** Previous versions defined `retentionDays` but never scheduled cleanup, so any persisted value sat dormant. Cleanup now runs once per day, right after the daily export. **If your persisted config has `retentionDays` set to anything other than `0` and you don't want daily deletion of older data, set it to `0` (keep forever) before upgrading.** Older installs may carry a persisted `retentionDays: 7` that was the legacy default; check via the SignalK admin UI under the SignalK to Parquet plugin config. The new default for fresh installs is `0`.
+
 ### Added
 
 - **GPX Track Import** (thanks @msallin, PR #51) — New workflow to load historical GPX tracks (recorded by other vessels, handhelds, or archived logs) directly into the Hive-partitioned parquet store, bypassing the live SignalK subscription path.

--- a/src/HistoryAPI.ts
+++ b/src/HistoryAPI.ts
@@ -65,16 +65,14 @@ export function registerHistoryApiRoute(
   app: any,
   sqliteBuffer?: SQLiteBufferInterface,
   autoDiscoveryService?: AutoDiscoveryService,
-  s3Config?: S3QueryConfig,
-  retentionDays: number = 7
+  s3Config?: S3QueryConfig
 ) {
   const historyApi = new HistoryAPI(
     selfId,
     dataDir,
     sqliteBuffer,
     autoDiscoveryService,
-    s3Config,
-    retentionDays
+    s3Config
   );
   // Handler for values endpoint
   const handleValues = (req: Request, res: Response) => {
@@ -473,21 +471,18 @@ export class HistoryAPI {
   private hivePathBuilder: HivePathBuilder;
   private autoDiscoveryService?: AutoDiscoveryService;
   private s3Config?: S3QueryConfig;
-  private retentionDays: number;
 
   constructor(
     private selfId: string,
     private dataDir: string,
     sqliteBuffer?: SQLiteBufferInterface,
     autoDiscoveryService?: AutoDiscoveryService,
-    s3Config?: S3QueryConfig,
-    retentionDays: number = 7
+    s3Config?: S3QueryConfig
   ) {
     this.sqliteBuffer = sqliteBuffer;
     this.hivePathBuilder = new HivePathBuilder();
     this.autoDiscoveryService = autoDiscoveryService;
     this.s3Config = s3Config;
-    this.retentionDays = retentionDays;
   }
 
   /**
@@ -858,12 +853,6 @@ export class HistoryAPI {
     // Convert ZonedDateTime to Date for S3 pattern building
     const fromDate = new Date(from.toInstant().toString());
     const toDate = new Date(to.toInstant().toString());
-
-    // Calculate retention cutoff for hybrid queries
-    const retentionCutoff = new Date();
-    retentionCutoff.setUTCDate(
-      retentionCutoff.getUTCDate() - this.retentionDays
-    );
 
     // If spatial filter is set, get valid timestamps from position data
     // This allows filtering non-position paths by "when vessel was in this area"

--- a/src/HistoryAPI.ts
+++ b/src/HistoryAPI.ts
@@ -56,6 +56,10 @@ import {
   InvalidResolutionError,
 } from './utils/duration-parser';
 import { isAngularPath } from './utils/angular-paths';
+import {
+  PathRetentionRule,
+  RetentionRuleSet,
+} from './utils/retention-rules';
 
 export function registerHistoryApiRoute(
   router: Pick<Router, 'get'>,
@@ -65,14 +69,16 @@ export function registerHistoryApiRoute(
   app: any,
   sqliteBuffer?: SQLiteBufferInterface,
   autoDiscoveryService?: AutoDiscoveryService,
-  s3Config?: S3QueryConfig
+  s3Config?: S3QueryConfig,
+  pathRetentionOverrides?: PathRetentionRule[]
 ) {
   const historyApi = new HistoryAPI(
     selfId,
     dataDir,
     sqliteBuffer,
     autoDiscoveryService,
-    s3Config
+    s3Config,
+    pathRetentionOverrides
   );
   // Handler for values endpoint
   const handleValues = (req: Request, res: Response) => {
@@ -471,18 +477,26 @@ export class HistoryAPI {
   private hivePathBuilder: HivePathBuilder;
   private autoDiscoveryService?: AutoDiscoveryService;
   private s3Config?: S3QueryConfig;
+  // Mirrors AggregationService's rule set so the read path can fall
+  // back to tier=raw for skipAggregation paths. The aggregation
+  // pipeline doesn't write 5s/60s/1h files for those, so a higher-
+  // resolution query against an aggregated tier would otherwise return
+  // empty.
+  private retentionRules: RetentionRuleSet;
 
   constructor(
     private selfId: string,
     private dataDir: string,
     sqliteBuffer?: SQLiteBufferInterface,
     autoDiscoveryService?: AutoDiscoveryService,
-    s3Config?: S3QueryConfig
+    s3Config?: S3QueryConfig,
+    pathRetentionOverrides?: PathRetentionRule[]
   ) {
     this.sqliteBuffer = sqliteBuffer;
     this.hivePathBuilder = new HivePathBuilder();
     this.autoDiscoveryService = autoDiscoveryService;
     this.s3Config = s3Config;
+    this.retentionRules = new RetentionRuleSet(pathRetentionOverrides || []);
   }
 
   /**
@@ -1029,7 +1043,22 @@ export class HistoryAPI {
         // Build file patterns based on query source
         let localFilePath: string | null = null;
         let s3FilePath: string | null = null;
-        const effectiveTier = tier || 'raw';
+        let effectiveTier = tier || 'raw';
+
+        // Honour per-path skipAggregation: AggregationService never wrote
+        // 5s/60s/1h files for these paths, so reading any aggregated tier
+        // would return empty. Fall back to raw — the existing object-path
+        // and string-path overrides further down handle their own special
+        // cases and run after this.
+        if (
+          effectiveTier !== 'raw' &&
+          this.retentionRules.shouldSkipAggregation(pathSpec.path)
+        ) {
+          debug(
+            `Path ${pathSpec.path}: skipAggregation rule matched — overriding tier=${effectiveTier} to raw`
+          );
+          effectiveTier = 'raw';
+        }
 
         // Always query local first
         const sanitizedContext = this.hivePathBuilder.sanitizeContext(context);

--- a/src/api-routes.ts
+++ b/src/api-routes.ts
@@ -49,7 +49,10 @@ import {
   CompactionConflictError,
   CompactionService,
 } from './services/compaction-service';
-import { AggregationService } from './services/aggregation-service';
+import {
+  AggregationService,
+  buildPerTierRetention,
+} from './services/aggregation-service';
 import { AggregationTier, HivePathBuilder } from './utils/hive-path-builder';
 import { isAngularPath } from './utils/angular-paths';
 import {
@@ -4977,12 +4980,11 @@ export function registerApiRoutes(
     {
       outputDirectory: state.getDataDirPath(),
       filenamePrefix: state.currentConfig?.filenamePrefix || 'signalk_data',
-      retentionDays: {
-        raw: state.currentConfig?.retentionDays || 7,
-        '5s': (state.currentConfig?.retentionDays || 7) * 2,
-        '60s': (state.currentConfig?.retentionDays || 7) * 4,
-        '1h': (state.currentConfig?.retentionDays || 7) * 12,
-      },
+      // ?? not || so explicit 0 (= keep forever) survives the coalesce.
+      retentionDays: buildPerTierRetention(
+        state.currentConfig?.retentionDays ?? 0
+      ),
+      pathRetentionOverrides: state.currentConfig?.pathRetentionOverrides,
     },
     app
   );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -41,3 +41,11 @@ export const GPX_UPLOAD_MAX_FILES = 500;
  * MigrationService - kept identical so both jobs feel the same.
  */
 export const IMPORT_JOB_TTL_MS = 30 * 60 * 1000;
+
+/**
+ * Retention cleanup: how many files to process between event-loop yields.
+ * Walking a large parquet tree shouldn't starve other plugin work (live
+ * data ingestion, SignalK websocket heartbeats) on slow disks, so the
+ * cleanup loop yields after this many files.
+ */
+export const CLEANUP_YIELD_INTERVAL = 200;

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,8 +40,33 @@ import {
 } from './history-provider';
 import { SQLiteBuffer } from './utils/sqlite-buffer';
 import { ParquetExportService } from './services/parquet-export-service';
-import { AggregationService } from './services/aggregation-service';
+import {
+  AggregationService,
+  buildPerTierRetention,
+} from './services/aggregation-service';
+import {
+  PathRetentionRule,
+  validatePathRetentionRules,
+} from './utils/retention-rules';
 import { AutoDiscoveryService } from './services/auto-discovery';
+
+/**
+ * Validate `pathRetentionOverrides` from the persisted config. Bad
+ * entries are dropped (with a logged error) rather than crashing
+ * plugin start; the SignalK admin UI enforces shape via JSON Schema
+ * for UI-driven changes, but a hand-edited config can bypass that.
+ */
+function parsePathRetentionOverrides(
+  raw: unknown,
+  app: ServerAPI
+): PathRetentionRule[] | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  const { rules, errors } = validatePathRetentionRules(raw);
+  for (const err of errors) {
+    app.error(`[Retention] Dropping invalid override: ${err}`);
+  }
+  return rules.length > 0 ? rules : undefined;
+}
 
 export default function (app: ServerAPI): SignalKPlugin {
   const plugin: SignalKPlugin = {
@@ -99,7 +124,16 @@ export default function (app: ServerAPI): SignalKPlugin {
         ? options.outputDirectory.trim()
         : app.getDataDirPath(),
       filenamePrefix: options?.filenamePrefix || 'signalk_data',
-      retentionDays: options?.retentionDays || 7,
+      retentionDays:
+        typeof options?.retentionDays === 'number' &&
+        Number.isFinite(options.retentionDays) &&
+        options.retentionDays >= 0
+          ? options.retentionDays
+          : 0,
+      pathRetentionOverrides: parsePathRetentionOverrides(
+        options?.pathRetentionOverrides,
+        app
+      ),
       fileFormat: options?.fileFormat || 'parquet',
       vesselMMSI: vesselMMSI,
       cloudUpload: (() => {
@@ -332,12 +366,10 @@ export default function (app: ServerAPI): SignalKPlugin {
         {
           outputDirectory: state.currentConfig.outputDirectory,
           filenamePrefix: state.currentConfig.filenamePrefix,
-          retentionDays: {
-            raw: state.currentConfig.retentionDays,
-            '5s': state.currentConfig.retentionDays * 2,
-            '60s': state.currentConfig.retentionDays * 4,
-            '1h': state.currentConfig.retentionDays * 12,
-          },
+          retentionDays: buildPerTierRetention(
+            state.currentConfig.retentionDays
+          ),
+          pathRetentionOverrides: state.currentConfig.pathRetentionOverrides,
         },
         app
       );
@@ -363,26 +395,74 @@ export default function (app: ServerAPI): SignalKPlugin {
             `[DailyExport] Exported ${result.recordsExported} records to ${result.filesCreated.length} files`
           );
 
-          // Run aggregation after daily export if Hive partitioning is enabled
+          // Run aggregation after daily export if Hive partitioning is enabled.
+          // Track whether aggregation and upload succeeded — cleanup must NOT
+          // run if either failed, because the whole point of post-pipeline
+          // cleanup is that files about to be deleted have already been
+          // rolled up and (when configured) uploaded.
+          let aggregationOk = false;
+          let uploadOk = false;
           if (aggregationService) {
             try {
               const aggResults = await aggregationService.runDailyAggregation();
+              const aggHadErrors = aggResults.some(r => r.errors.length > 0);
+              aggregationOk = !aggHadErrors;
               app.debug(
-                `[DailyExport] Aggregation complete: ${JSON.stringify(aggResults.map(r => ({ tier: r.targetTier, files: r.filesCreated })))}`
+                `[DailyExport] Aggregation complete: ${JSON.stringify(aggResults.map(r => ({ tier: r.targetTier, files: r.filesCreated, errors: r.errors.length })))}`
               );
+            } catch (aggErr) {
+              app.error(
+                `[DailyExport] Aggregation failed: ${(aggErr as Error).message}`
+              );
+            }
 
-              // Upload files to cloud after aggregation
-              if (state.currentConfig?.cloudUpload.provider !== 'none') {
+            const cloudEnabled =
+              state.currentConfig?.cloudUpload.provider !== 'none';
+            if (cloudEnabled && aggregationOk) {
+              try {
                 await uploadConsolidatedFilesToS3(
                   state.currentConfig!,
                   yesterday,
                   state,
                   app
                 );
+                uploadOk = true;
+              } catch (upErr) {
+                app.error(
+                  `[DailyExport] Cloud upload failed: ${(upErr as Error).message}`
+                );
               }
-            } catch (aggErr) {
+            } else if (!cloudEnabled) {
+              uploadOk = true; // No upload required → vacuously OK.
+            }
+
+            // Apply retention rules. Skipped if aggregation or (when
+            // applicable) upload didn't complete cleanly: short-retention
+            // raw files we'd be about to delete may not have been rolled
+            // up or synced yet, so deleting them now would lose data.
+            const cfg = state.currentConfig!;
+            const willDeleteAnything =
+              cfg.retentionDays > 0 ||
+              (cfg.pathRetentionOverrides &&
+                cfg.pathRetentionOverrides.length > 0);
+            if (willDeleteAnything && aggregationOk && uploadOk) {
+              try {
+                const cleanup = await aggregationService.cleanupOldData();
+                const summary = `[DailyExport] Retention cleanup: ${cleanup.deletedFiles} files removed, ${cleanup.failedFiles} failed, ${(cleanup.freedBytes / 1024 / 1024).toFixed(2)} MB freed`;
+                if (cleanup.failedFiles > 0) {
+                  app.error(summary);
+                } else {
+                  app.debug(summary);
+                }
+              } catch (cleanErr) {
+                app.error(
+                  `[DailyExport] Retention cleanup failed: ${(cleanErr as Error).message}`
+                );
+              }
+            } else if (willDeleteAnything) {
               app.error(
-                `[DailyExport] Aggregation failed: ${(aggErr as Error).message}`
+                `[DailyExport] Retention cleanup SKIPPED: aggregation or upload did not complete cleanly. ` +
+                  `Short-retention paths will accumulate until the next successful run.`
               );
             }
           }
@@ -512,8 +592,7 @@ export default function (app: ServerAPI): SignalKPlugin {
         app,
         state.sqliteBuffer, // Pass SQLite buffer for federated queries
         state.autoDiscoveryService, // Pass auto-discovery service
-        s3QueryConfig, // S3 config for federated queries
-        state.currentConfig.retentionDays // Retention days for local/S3 cutoff
+        s3QueryConfig // S3 config for federated queries
       );
       app.debug(
         `[AutoDiscovery] History API registered with autoDiscoveryService: ${!!state.autoDiscoveryService}`
@@ -744,15 +823,47 @@ export default function (app: ServerAPI): SignalKPlugin {
           'Prefix added to all generated Parquet files. Useful if running multiple instances or for organizing data. Example: "boat_name" produces "boat_name_2024-01-15T1200.parquet"',
         default: 'signalk_data',
       },
-      // retentionDays: {
-      //   type: 'number',
-      //   title: 'Retention Period (days)',
-      //   description:
-      //     'Number of days to keep raw Parquet files on disk. Higher tiers are retained longer automatically (5s: 2x, 60s: 4x, 1h: 12x).',
-      //   default: 7,
-      //   minimum: 1,
-      //   maximum: 365,
-      // },
+      retentionDays: {
+        type: 'integer',
+        title: 'Retention Period (days)',
+        description:
+          'Days to keep raw-tier Parquet files. Aggregated tiers scale automatically (5s: 2x, 60s: 4x, 1h: 12x). 0 = keep forever (default). Cleanup runs once per day, right after the daily export.',
+        default: 0,
+        minimum: 0,
+        maximum: 36500,
+      },
+      pathRetentionOverrides: {
+        type: 'array',
+        title: 'Per-Path Retention Overrides',
+        description:
+          'Override retention for specific SignalK paths. Each rule has a glob pattern (* matches any chars, including dots), a number of days (0 = keep forever), and an optional skipAggregation flag (true = path stays raw-only, never rolled up). The most specific pattern wins; ties broken in declaration order. Example: pattern "environment.wind.*", days 1, skipAggregation true => wind paths kept for 24h in tier=raw and never aggregated.',
+        items: {
+          type: 'object',
+          required: ['pattern', 'days'],
+          properties: {
+            pattern: {
+              type: 'string',
+              title: 'Path pattern',
+              description: 'Glob over the SignalK path. * matches any chars.',
+            },
+            days: {
+              type: 'integer',
+              title: 'Days',
+              description: '0 = keep forever.',
+              minimum: 0,
+              maximum: 36500,
+            },
+            skipAggregation: {
+              type: 'boolean',
+              title: 'Skip aggregation',
+              description:
+                'When true, paths matching this rule are not rolled up into 5s/60s/1h tiers.',
+              default: false,
+            },
+          },
+        },
+        default: [],
+      },
       exportBatchSize: {
         type: 'number',
         title: 'Export Batch Size',

--- a/src/index.ts
+++ b/src/index.ts
@@ -441,10 +441,12 @@ export default function (app: ServerAPI): SignalKPlugin {
             // raw files we'd be about to delete may not have been rolled
             // up or synced yet, so deleting them now would lose data.
             const cfg = state.currentConfig!;
+            // A pure skipAggregation override (days = 0) doesn't expire
+            // anything, so it shouldn't trigger a daily walk of the
+            // store. Only count overrides that can actually delete.
             const willDeleteAnything =
               cfg.retentionDays > 0 ||
-              (cfg.pathRetentionOverrides &&
-                cfg.pathRetentionOverrides.length > 0);
+              !!cfg.pathRetentionOverrides?.some(rule => rule.days > 0);
             if (willDeleteAnything && aggregationOk && uploadOk) {
               try {
                 const cleanup = await aggregationService.cleanupOldData();
@@ -592,7 +594,8 @@ export default function (app: ServerAPI): SignalKPlugin {
         app,
         state.sqliteBuffer, // Pass SQLite buffer for federated queries
         state.autoDiscoveryService, // Pass auto-discovery service
-        s3QueryConfig // S3 config for federated queries
+        s3QueryConfig, // S3 config for federated queries
+        state.currentConfig.pathRetentionOverrides // skipAggregation read-path fallback
       );
       app.debug(
         `[AutoDiscovery] History API registered with autoDiscoveryService: ${!!state.autoDiscoveryService}`

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,6 +117,32 @@ export default function (app: ServerAPI): SignalKPlugin {
       (app.getSelfPath('name') as any) ||
       'unknown_vessel';
 
+    // One-shot legacy retention migration. Pre-0.7.40 the home-port
+    // action's savePluginOptions side effect baked retentionDays = 7
+    // into saved configs even though cleanup was never scheduled, so
+    // the value sat dormant. Now that cleanup actually runs, an
+    // upgrader who never deliberately set retention would suddenly
+    // start losing data. The configSchemaVersion sentinel lets us
+    // distinguish "saved 7 from old default" (no stamp) from "saved 7
+    // from explicit choice" (stamp present from prior run): once we
+    // stamp, the migration condition fails forever for that install,
+    // so re-entering 7 in the UI is honoured on next start.
+    const needsLegacyRetentionMigration =
+      options?.configSchemaVersion === undefined &&
+      options?.retentionDays === 7 &&
+      (!Array.isArray(options?.pathRetentionOverrides) ||
+        options.pathRetentionOverrides.length === 0);
+
+    if (needsLegacyRetentionMigration) {
+      app.error(
+        '[Retention] Detected legacy retentionDays=7 from a pre-0.7.40 install. ' +
+          'Previous versions baked this default into saved configs as a side effect ' +
+          'of the home-port action but never enforced it. Treating as 0 (keep forever) ' +
+          'and persisting the change. To opt into 7-day retention, set ' +
+          '"Retention Period (days)" to 7 in the plugin admin UI.'
+      );
+    }
+
     state.currentConfig = {
       bufferSize: options?.bufferSize || 1000,
       saveIntervalSeconds: options?.saveIntervalSeconds || 30,
@@ -124,16 +150,18 @@ export default function (app: ServerAPI): SignalKPlugin {
         ? options.outputDirectory.trim()
         : app.getDataDirPath(),
       filenamePrefix: options?.filenamePrefix || 'signalk_data',
-      retentionDays:
-        typeof options?.retentionDays === 'number' &&
-        Number.isFinite(options.retentionDays) &&
-        options.retentionDays >= 0
+      retentionDays: needsLegacyRetentionMigration
+        ? 0
+        : typeof options?.retentionDays === 'number' &&
+            Number.isFinite(options.retentionDays) &&
+            options.retentionDays >= 0
           ? options.retentionDays
           : 0,
       pathRetentionOverrides: parsePathRetentionOverrides(
         options?.pathRetentionOverrides,
         app
       ),
+      configSchemaVersion: 1,
       fileFormat: options?.fileFormat || 'parquet',
       vesselMMSI: vesselMMSI,
       cloudUpload: (() => {
@@ -180,6 +208,19 @@ export default function (app: ServerAPI): SignalKPlugin {
       // Daily export hour (0-23 UTC, default 2 AM)
       dailyExportHour: options?.dailyExportHour ?? 4,
     };
+
+    // Persist the migration so the configSchemaVersion sentinel lands
+    // on disk; without this, every restart would re-trigger the
+    // legacy detection. Also writes the corrected retentionDays = 0.
+    if (needsLegacyRetentionMigration) {
+      app.savePluginOptions(state.currentConfig, (err?: unknown) => {
+        if (err) {
+          app.error(
+            `[Retention] Failed to persist legacy migration: ${(err as Error).message}`
+          );
+        }
+      });
+    }
 
     // Load webapp configuration including commands
     const webAppConfig = loadWebAppConfig(app);

--- a/src/services/aggregation-service.ts
+++ b/src/services/aggregation-service.ts
@@ -18,16 +18,53 @@ import { ServerAPI } from '@signalk/server-api';
 import { DuckDBPool } from '../utils/duckdb-pool';
 import { HivePathBuilder, AggregationTier } from '../utils/hive-path-builder';
 import { isAngularPath } from '../utils/angular-paths';
-import { POSITION_MAX_SPEED_MPS } from '../constants';
+import { CLEANUP_YIELD_INTERVAL, POSITION_MAX_SPEED_MPS } from '../constants';
+import { PathRetentionRule, RetentionRuleSet } from '../utils/retention-rules';
 
 export interface AggregationConfig {
   outputDirectory: string;
   filenamePrefix: string;
+  // Per-tier retention in days. 0 means "keep forever". Tiers above raw
+  // are multiples of the raw value by convention (5s=2x, 60s=4x,
+  // 1h=12x), but they are passed in independently so the route layer
+  // can override.
   retentionDays: {
     raw: number;
     '5s': number;
     '60s': number;
     '1h': number;
+  };
+  // Optional per-path overrides applied on top of the tier defaults.
+  // The override's `days` value is the raw retention; the same tier
+  // multipliers (2/4/12x) scale it to upper tiers. `skipAggregation`
+  // removes a path from the rollup pipeline entirely.
+  pathRetentionOverrides?: PathRetentionRule[];
+}
+
+// Tier multipliers used when scaling a raw-tier retention to upper
+// tiers. The same convention applies to the global default and to
+// per-path overrides; exported so callers in index.ts and the route
+// layer build identical AggregationConfig.retentionDays without
+// drifting from this file.
+export const TIER_RETENTION_MULTIPLIER: Record<AggregationTier, number> = {
+  raw: 1,
+  '5s': 2,
+  '60s': 4,
+  '1h': 12,
+};
+
+/**
+ * Build the per-tier retention block from a raw-tier value. 0 stays
+ * 0 in every tier (= keep forever).
+ */
+export function buildPerTierRetention(
+  rawDays: number
+): AggregationConfig['retentionDays'] {
+  return {
+    raw: rawDays * TIER_RETENTION_MULTIPLIER.raw,
+    '5s': rawDays * TIER_RETENTION_MULTIPLIER['5s'],
+    '60s': rawDays * TIER_RETENTION_MULTIPLIER['60s'],
+    '1h': rawDays * TIER_RETENTION_MULTIPLIER['1h'],
   };
 }
 
@@ -94,6 +131,7 @@ export class AggregationService {
   private readonly config: AggregationConfig;
   private readonly app: ServerAPI;
   private readonly hivePathBuilder: HivePathBuilder;
+  private readonly retentionRules: RetentionRuleSet;
   private currentJob: AggregationProgress | null = null;
   private cancelRequested: boolean = false;
 
@@ -101,6 +139,17 @@ export class AggregationService {
     this.config = config;
     this.app = app;
     this.hivePathBuilder = new HivePathBuilder();
+    this.retentionRules = new RetentionRuleSet(
+      config.pathRetentionOverrides || [],
+      (rule, err) => {
+        // A pattern that fails to compile is dropped; log so the
+        // operator sees the offending rule rather than silently losing
+        // it. Doesn't block plugin start.
+        this.app.error(
+          `[Retention] Dropping rule with invalid pattern '${rule.pattern}': ${err.message}`
+        );
+      }
+    );
   }
 
   /**
@@ -210,6 +259,14 @@ export class AggregationService {
       try {
         const { context, signalkPath } = this.parseGroupKey(key);
         if (pathFilter && !pathFilter(signalkPath)) continue;
+        // Honour per-path skipAggregation. These paths live only in
+        // tier=raw and are cleaned up directly via cleanupOldData.
+        if (this.retentionRules.shouldSkipAggregation(signalkPath)) {
+          this.app.debug(
+            `Skipping aggregation for ${signalkPath}: matched a retention rule with skipAggregation=true`
+          );
+          continue;
+        }
         const result = await this.aggregateGroup(
           files,
           context,
@@ -645,23 +702,42 @@ export class AggregationService {
   }
 
   /**
-   * Clean up old data based on retention settings
+   * Clean up old data based on retention settings.
+   *
+   * Per-tier retention defaults come from `config.retentionDays`. A
+   * value of 0 at any tier means "keep forever" — that tier is skipped
+   * entirely. Per-path overrides take precedence: when a file's path
+   * matches a retention rule, the rule's `days` (scaled by the tier
+   * multiplier) is used instead of the global tier default.
+   *
+   * Files outside the Hive layout (legacy flat storage) are not
+   * touched: there is no path/year/day to anchor a retention decision
+   * on.
    */
   async cleanupOldData(): Promise<{
     deletedFiles: number;
+    failedFiles: number;
     freedBytes: number;
   }> {
     let deletedFiles = 0;
+    let failedFiles = 0;
     let freedBytes = 0;
 
     const now = new Date();
+    const hasPathRules = !this.retentionRules.isEmpty();
+    let processedSinceYield = 0;
 
     for (const tier of TIER_HIERARCHY) {
-      const retentionDays = this.config.retentionDays[tier];
-      const cutoffDate = new Date(now);
-      cutoffDate.setUTCDate(cutoffDate.getUTCDate() - retentionDays);
+      if (this.cancelRequested) break;
 
-      // Find files older than retention period
+      const tierDefaultDays = this.config.retentionDays[tier];
+      // No tier default and no per-path overrides → nothing to do for
+      // this tier. With overrides present we still walk the tier so
+      // path-specific rules can act even when the global is infinite.
+      if (tierDefaultDays <= 0 && !hasPathRules) continue;
+
+      const tierMultiplier = TIER_RETENTION_MULTIPLIER[tier];
+
       const pattern = path.join(
         this.config.outputDirectory,
         `tier=${tier}`,
@@ -672,34 +748,89 @@ export class AggregationService {
       const files = await glob(pattern);
 
       for (const file of files) {
+        if (this.cancelRequested) break;
+        if (++processedSinceYield >= CLEANUP_YIELD_INTERVAL) {
+          processedSinceYield = 0;
+          await new Promise(resolve => setImmediate(resolve));
+        }
+
         try {
           const parsed = this.hivePathBuilder.detectPathStyle(file);
-          if (parsed.isHive && parsed.year && parsed.dayOfYear) {
-            const fileDate = this.hivePathBuilder.dateFromDayOfYear(
-              parsed.year,
-              parsed.dayOfYear
-            );
+          if (!parsed.isHive || !parsed.year || !parsed.dayOfYear) continue;
 
-            if (fileDate < cutoffDate) {
-              const stats = await fs.stat(file);
-              freedBytes += stats.size;
-              await fs.remove(file);
-              deletedFiles++;
-            }
+          const effectiveDays = this.resolveEffectiveRetentionDays(
+            parsed.signalkPath,
+            tierDefaultDays,
+            tierMultiplier
+          );
+          // null means keep forever for this (path, tier) pair.
+          if (effectiveDays === null) continue;
+
+          // Compare at day granularity (midnight UTC). The partition's
+          // fileDate is midnight UTC; if cutoffDate kept the current
+          // time-of-day, a `days: 1` cleanup running mid-afternoon
+          // would already see "yesterday" as older than cutoff and
+          // delete it ~16 hours before its day was actually complete.
+          const cutoffDate = new Date(now);
+          cutoffDate.setUTCHours(0, 0, 0, 0);
+          cutoffDate.setUTCDate(cutoffDate.getUTCDate() - effectiveDays);
+
+          const fileDate = this.hivePathBuilder.dateFromDayOfYear(
+            parsed.year,
+            parsed.dayOfYear
+          );
+
+          if (fileDate < cutoffDate) {
+            const stats = await fs.stat(file);
+            await fs.remove(file);
+            freedBytes += stats.size;
+            deletedFiles++;
           }
         } catch (error) {
-          this.app.debug(
+          this.app.error(
             `Failed to check/delete ${file}: ${(error as Error).message}`
           );
+          failedFiles++;
         }
       }
     }
 
     this.app.debug(
-      `Cleanup: deleted ${deletedFiles} files, freed ${(freedBytes / 1024 / 1024).toFixed(2)} MB`
+      `Cleanup: deleted ${deletedFiles} files, ${failedFiles} failed, freed ${(freedBytes / 1024 / 1024).toFixed(2)} MB`
     );
 
-    return { deletedFiles, freedBytes };
+    return { deletedFiles, failedFiles, freedBytes };
+  }
+
+  /**
+   * Pick the retention to apply for one (path, tier) pair.
+   *
+   * - If a path-rule matches and `skipAggregation` is set: use rule.days
+   *   for every tier (no multiplier). The path lives only in raw, so
+   *   any stale rows in upper tiers should sweep at the same horizon
+   *   as raw rather than linger 2/4/12x longer.
+   * - Else if a path-rule matches: use rule.days × tierMultiplier
+   *   (rule.days is interpreted as raw-tier retention; upper tiers
+   *   scale by the same convention as the global default).
+   * - Else: use the global tier default.
+   * - 0 (from either source) means infinite — return null so the caller
+   *   skips deletion.
+   */
+  private resolveEffectiveRetentionDays(
+    signalkPath: string | undefined,
+    tierDefaultDays: number,
+    tierMultiplier: number
+  ): number | null {
+    if (signalkPath) {
+      const matched = this.retentionRules.match(signalkPath);
+      if (matched) {
+        if (matched.days <= 0) return null;
+        return matched.skipAggregation
+          ? matched.days
+          : matched.days * tierMultiplier;
+      }
+    }
+    return tierDefaultDays > 0 ? tierDefaultDays : null;
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,12 @@ export interface PluginConfig {
   // including dots); most-specific pattern wins, ties broken by
   // declaration order. See utils/retention-rules.ts.
   pathRetentionOverrides?: import('./utils/retention-rules').PathRetentionRule[];
+  // Bumped each time we run a non-trivial migration over saved options.
+  // Absent on installs that have never started 0.7.40+. Used to make
+  // migrations one-shot — once we've seen and stamped a config, we
+  // trust the values in it literally (so an operator who explicitly
+  // re-enters the legacy default in the UI keeps it on next start).
+  configSchemaVersion?: number;
   fileFormat: 'json' | 'csv' | 'parquet';
   vesselMMSI: string;
   cloudUpload: CloudUploadConfig;

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,7 +48,15 @@ export interface PluginConfig {
   saveIntervalSeconds: number;
   outputDirectory: string;
   filenamePrefix: string;
+  // Global retention period in days for tier=raw. Tiers above raw use a
+  // multiplier (5s=2x, 60s=4x, 1h=12x). 0 means "keep forever" — the
+  // historical default behaviour, since the cleanup job was previously
+  // never scheduled.
   retentionDays: number;
+  // Optional per-path overrides. Match by glob (`*` matches any chars
+  // including dots); most-specific pattern wins, ties broken by
+  // declaration order. See utils/retention-rules.ts.
+  pathRetentionOverrides?: import('./utils/retention-rules').PathRetentionRule[];
   fileFormat: 'json' | 'csv' | 'parquet';
   vesselMMSI: string;
   cloudUpload: CloudUploadConfig;

--- a/src/utils/retention-rules.ts
+++ b/src/utils/retention-rules.ts
@@ -1,0 +1,203 @@
+/**
+ * Per-path retention rules.
+ *
+ * The plugin keeps a single global `retentionDays` value (0 = keep
+ * forever). On top of that, operators can declare a list of overrides:
+ *
+ *   [{ pattern: 'environment.wind.*', days: 1, skipAggregation: true }]
+ *
+ * meaning: any SignalK path matching `environment.wind.*` is kept for
+ * one day in tier=raw and is NOT aggregated into 5s/60s/1h tiers.
+ *
+ * Pattern syntax: glob with `*` matching zero-or-more characters
+ * (including dots — `environment.wind.*` covers `environment.wind.deep.x`
+ * too). Other characters are literal.
+ *
+ * Resolution: when more than one rule matches a path, the rule with the
+ * most non-wildcard characters wins (rough proxy for "most specific").
+ * Ties are broken in declaration order.
+ */
+export interface PathRetentionRule {
+  // Glob pattern over the SignalK path. `*` matches any chars, including
+  // dots. Examples: `environment.wind.*`, `environment.*.depth`,
+  // `navigation.position`.
+  pattern: string;
+
+  // Days to keep; 0 means keep forever (the same convention as the
+  // global retentionDays setting).
+  days: number;
+
+  // When true, the live aggregation pipeline will not roll this path up
+  // into 5s/60s/1h tiers — useful for high-volume paths where a short
+  // retention is the only sensible policy.
+  skipAggregation?: boolean;
+}
+
+interface CompiledRule {
+  rule: PathRetentionRule;
+  regex: RegExp;
+  specificity: number;
+  declarationOrder: number;
+}
+
+/**
+ * Glob-to-regex with the simple `*` semantics described above.
+ *
+ * Multiple consecutive `*` characters are collapsed to a single `*`
+ * before compilation. This both keeps the regex tidy and shuts the
+ * door on ReDoS via patterns like `*****foo*****` — without the
+ * collapse, runs of `.*` against a long non-matching input cause
+ * catastrophic backtracking.
+ */
+function compilePattern(pattern: string): RegExp {
+  const collapsed = pattern.replace(/\*+/g, '*');
+  // Escape every regex special character except `*`, then turn `*` into
+  // `.*`. Anchor full-string.
+  const escaped = collapsed.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+  const regex = escaped.replace(/\*/g, '.*');
+  return new RegExp(`^${regex}$`);
+}
+
+/**
+ * Specificity is the count of literal (non-`*`) characters in the
+ * pattern. `environment.wind.speedApparent` (29 literal chars) beats
+ * `environment.wind.*` (16 literal chars) which beats `*` (0 literal
+ * chars). It's a rough heuristic, but it does the right thing for the
+ * shapes operators actually write.
+ */
+function computeSpecificity(pattern: string): number {
+  let n = 0;
+  for (const ch of pattern) if (ch !== '*') n++;
+  return n;
+}
+
+export class RetentionRuleSet {
+  private readonly rules: CompiledRule[];
+
+  /**
+   * Construct with a list of rules. Per-rule compile failures (from a
+   * malformed pattern in a hand-edited config) are not fatal — the bad
+   * rule is dropped and `onCompileError` is invoked so the caller can
+   * surface it. This keeps a single typo from poisoning plugin start.
+   */
+  constructor(
+    rules: PathRetentionRule[] = [],
+    onCompileError?: (rule: PathRetentionRule, error: Error) => void
+  ) {
+    const compiled: CompiledRule[] = [];
+    rules.forEach((rule, i) => {
+      try {
+        compiled.push({
+          rule,
+          regex: compilePattern(rule.pattern),
+          specificity: computeSpecificity(rule.pattern),
+          declarationOrder: i,
+        });
+      } catch (err) {
+        if (onCompileError) onCompileError(rule, err as Error);
+      }
+    });
+    this.rules = compiled;
+  }
+
+  /**
+   * Resolve the matching rule for a given SignalK path, or null if none
+   * matches. The caller decides whether to fall back to the global
+   * retention default.
+   */
+  match(signalkPath: string): PathRetentionRule | null {
+    let best: CompiledRule | null = null;
+    for (const c of this.rules) {
+      if (!c.regex.test(signalkPath)) continue;
+      if (
+        best === null ||
+        c.specificity > best.specificity ||
+        (c.specificity === best.specificity &&
+          c.declarationOrder < best.declarationOrder)
+      ) {
+        best = c;
+      }
+    }
+    return best ? best.rule : null;
+  }
+
+  /**
+   * Resolve effective retention for a path. Falls back to the global
+   * default when no rule matches. `null` means "keep forever".
+   */
+  resolveRetentionDays(
+    signalkPath: string,
+    globalDefaultDays: number
+  ): number | null {
+    const matched = this.match(signalkPath);
+    const days = matched ? matched.days : globalDefaultDays;
+    return days > 0 ? days : null;
+  }
+
+  /**
+   * True if aggregation should skip this path (because a matching rule
+   * has skipAggregation set).
+   */
+  shouldSkipAggregation(signalkPath: string): boolean {
+    return this.match(signalkPath)?.skipAggregation === true;
+  }
+
+  isEmpty(): boolean {
+    return this.rules.length === 0;
+  }
+}
+
+/**
+ * Validate a list of rules. Always returns the valid rules plus any
+ * per-entry errors so callers can drop only the bad entries instead of
+ * all of them. A non-array input returns `rules: []` with one error.
+ */
+export function validatePathRetentionRules(rules: unknown): {
+  rules: PathRetentionRule[];
+  errors: string[];
+} {
+  if (!Array.isArray(rules)) {
+    return { rules: [], errors: ['pathRetentionOverrides must be an array'] };
+  }
+  const errors: string[] = [];
+  const out: PathRetentionRule[] = [];
+  rules.forEach((entry, i) => {
+    if (typeof entry !== 'object' || entry === null) {
+      errors.push(`pathRetentionOverrides[${i}] must be an object`);
+      return;
+    }
+    const r = entry as Record<string, unknown>;
+    if (typeof r.pattern !== 'string' || r.pattern.length === 0) {
+      errors.push(
+        `pathRetentionOverrides[${i}].pattern must be a non-empty string`
+      );
+      return;
+    }
+    if (
+      typeof r.days !== 'number' ||
+      !Number.isFinite(r.days) ||
+      !Number.isInteger(r.days) ||
+      r.days < 0
+    ) {
+      errors.push(
+        `pathRetentionOverrides[${i}].days must be a non-negative integer`
+      );
+      return;
+    }
+    if (
+      r.skipAggregation !== undefined &&
+      typeof r.skipAggregation !== 'boolean'
+    ) {
+      errors.push(
+        `pathRetentionOverrides[${i}].skipAggregation must be a boolean`
+      );
+      return;
+    }
+    out.push({
+      pattern: r.pattern,
+      days: r.days,
+      skipAggregation: r.skipAggregation === true ? true : undefined,
+    });
+  });
+  return { rules: out, errors };
+}

--- a/src/utils/retention-rules.ts
+++ b/src/utils/retention-rules.ts
@@ -150,12 +150,17 @@ export class RetentionRuleSet {
 /**
  * Validate a list of rules. Always returns the valid rules plus any
  * per-entry errors so callers can drop only the bad entries instead of
- * all of them. A non-array input returns `rules: []` with one error.
+ * all of them. Omitted input (undefined / null) is valid and yields an
+ * empty rule set; a present-but-non-array input returns `rules: []` with
+ * one error.
  */
 export function validatePathRetentionRules(rules: unknown): {
   rules: PathRetentionRule[];
   errors: string[];
 } {
+  if (rules === undefined || rules === null) {
+    return { rules: [], errors: [] };
+  }
   if (!Array.isArray(rules)) {
     return { rules: [], errors: ['pathRetentionOverrides must be an array'] };
   }


### PR DESCRIPTION
## Summary

Wires up the dormant retention pipeline and adds per-path overrides. Until now `retentionDays` existed on the config type but the schema option was commented out and the cleanup job was never scheduled — every install kept everything forever. Operators who want different retention for high-volume paths (e.g. NMEA wind) had no way to express that.

## Behaviour

- **New default `retentionDays = 0`** means "keep forever". Fresh installs see no behavioural change.
- **One-shot legacy migration** (commit `328fd20`): pre-0.7.40 installs may carry a persisted `retentionDays: 7` baked in by the home-port action's `savePluginOptions` side effect. On first start under 0.7.40+, if the saved config has no `configSchemaVersion` stamp, `retentionDays === 7`, and no per-path overrides, the value is rewritten to `0`, an `app.error` is logged, and the migrated config is persisted (stamps `configSchemaVersion: 1`). On subsequent starts the stamp is present, so an operator who re-enters `7` in the admin UI keeps it.
- **Cleanup runs once per day**, right after the daily export, only when retention is actually configured AND aggregation + upload completed cleanly. Aggregation/upload failure → cleanup is skipped and logged at error level so operators know short-retention paths are accumulating.
- **Per-path overrides** match by glob (`*` matches any chars including dots; consecutive `*` collapsed to defeat ReDoS). Most-specific pattern wins; ties broken in declaration order. `days = 0` means "keep forever" for that path. `skipAggregation: true` removes a path from the rollup pipeline (lives only in tier=raw).
- **Override `days`** is the raw-tier retention; the existing tier multipliers (5s=2x, 60s=4x, 1h=12x) scale it to upper tiers.

## Operator example (the wind use case)

```yaml
retentionDays: 0
pathRetentionOverrides:
  - pattern: 'environment.wind.*'
    days: 1
    skipAggregation: true
```

Wind paths kept for 24h in tier=raw, never aggregated, deleted by the daily cleanup. Everything else keeps the global default.
