### PR TITLE
fix(history): align resolution parsing with SignalK spec

### DIFF
--- a/src/HistoryAPI.ts
+++ b/src/HistoryAPI.ts
@@ -53,6 +53,7 @@ import {
 import {
   parseDurationToMillis,
   parseResolutionToMillis,
+  InvalidResolutionError,
 } from './utils/duration-parser';
 import { isAngularPath } from './utils/angular-paths';
 
@@ -825,6 +826,11 @@ export class HistoryAPI {
       allResult = this.convertToLocalTime(allResult);
       res.json(allResult);
     } catch (error) {
+      if (error instanceof InvalidResolutionError) {
+        debug(`Bad request in getValues: ${error.message}`);
+        res.status(400).json({ error: error.message });
+        return;
+      }
       debug(`Error in getValues: ${error}`);
       res.status(500).json({
         error: 'Internal server error',

--- a/src/utils/duration-parser.ts
+++ b/src/utils/duration-parser.ts
@@ -41,33 +41,64 @@ export function parseDurationToMillis(duration: string): number {
   throw new Error(`Invalid duration: ${duration}. Use PT1H, 3600, or 1h`);
 }
 
+export class InvalidResolutionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidResolutionError';
+  }
+}
+
+const RESOLUTION_UNIT_MILLIS: Record<string, number> = {
+  s: 1_000,
+  m: 60_000,
+  h: 3_600_000,
+  d: 86_400_000,
+};
+
+const RESOLUTION_TIME_EXPRESSION = /^(\d+)([smhd])$/i;
+
 /**
- * Parse resolution (in seconds), return milliseconds.
- * Supports: 60, 1m, 5s, 1h
+ * Parse the History API `resolution` query parameter into milliseconds.
+ *
+ * Per the SignalK History API spec, resolution is a number of seconds or a
+ * time expression of the form `<integer><unit>` where unit is s|m|h|d.
  */
-export function parseResolutionToMillis(resolution: string): number {
+export function parseResolutionToMillis(resolution: string | number): number {
+  const reject = (): never => {
+    throw new InvalidResolutionError(
+      `resolution parameter must be a positive number of seconds or a time expression like '1s', '1m', '1h', '1d'`
+    );
+  };
+  const toMillisOrReject = (seconds: number): number => {
+    const millis = seconds * 1000;
+    if (!Number.isFinite(millis) || millis <= 0) reject();
+    return millis;
+  };
+
+  if (typeof resolution === 'number') {
+    if (!Number.isFinite(resolution) || resolution <= 0) reject();
+    return toMillisOrReject(resolution);
+  }
+
+  // Express can hand us an array (?resolution=1s&resolution=2s) typed as
+  // string by the route layer's cast; reject anything that isn't actually
+  // a string before calling .trim().
+  if (typeof resolution !== 'string') reject();
+
   const trimmed = resolution.trim();
-
-  // Time expression (1s, 1m, 1h)
-  const match = trimmed.match(/^(\d+(?:\.\d+)?)([smh])$/i);
+  const match = RESOLUTION_TIME_EXPRESSION.exec(trimmed);
   if (match) {
-    const value = parseFloat(match[1]);
-    const unit = match[2].toLowerCase();
-    switch (unit) {
-      case 's':
-        return value * 1000;
-      case 'm':
-        return value * 60 * 1000;
-      case 'h':
-        return value * 60 * 60 * 1000;
-    }
+    const value = Number(match[1]);
+    if (value <= 0) reject();
+    const millis = value * RESOLUTION_UNIT_MILLIS[match[2].toLowerCase()];
+    if (!Number.isFinite(millis) || millis <= 0) reject();
+    return millis;
   }
 
-  // Integer/float seconds
-  const seconds = parseFloat(trimmed);
-  if (!isNaN(seconds)) {
-    return seconds * 1000;
+  const asNumber = Number(trimmed);
+  if (trimmed !== '' && Number.isFinite(asNumber) && asNumber > 0) {
+    return toMillisOrReject(asNumber);
   }
 
-  throw new Error(`Invalid resolution: ${resolution}. Use 60 or 1m`);
+  return reject();
 }


### PR DESCRIPTION
## Summary

Aligns the History API `resolution` query-parameter parsing with the spec, mirroring the fix made upstream in [signalk-server#2643](https://github.com/SignalK/signalk-server/pull/2643).

The History API spec describes `resolution` as

> Length of data sample time window in seconds or as a time expression ('1s', '1m', '1h', '1d')

but `parseResolutionToMillis` only matched `s|m|h` in its regex and silently fell through to `parseFloat` for everything else. That had two visible effects:

- `?resolution=1d` was parsed as `1` (because `parseFloat('1d')` returns `1`) and treated as 1 second instead of 1 day.
- `?resolution=1y`, `?resolution=abc`, etc. were silently coerced via the same `parseFloat` slip rather than producing a useful error.

## Changes

- **`src/utils/duration-parser.ts`** — Add `d` (day) to the time-expression regex; switch the seconds fallback from `parseFloat` to `Number()` so trailing-junk strings (`1d`, `1y`, ...) no longer round-trip as `1 * 1000`. Throw a tagged `InvalidResolutionError` with a spec-aligned message.
- **`src/HistoryAPI.ts`** — V1 `/signalk/v1/history/values` catches `InvalidResolutionError` and returns `400` with the message rather than the previous `500 Internal server error`.

