### PR TITLE
fix(history): convert v2 resolution from seconds to ms

### DIFF
--- a/src/history-provider.ts
+++ b/src/history-provider.ts
@@ -154,12 +154,24 @@ export class HistoryProvider implements HistoryApi {
       query.context === ('self' as Context)
         ? (`vessels.${this.selfId}` as Context)
         : query.context;
-    const resolution =
-      query.resolution ||
-      Math.round(((to.toEpochSecond() - from.toEpochSecond()) / 500) * 1000);
+    // query.resolution is in seconds per the SignalK History API spec;
+    // the DuckDB bucketing SQL below works in milliseconds. Reject 0,
+    // negative, NaN, and Infinity here so they don't reach SQL as a
+    // divide-by-zero, negative bucket, or unbounded cardinality query.
+    const r = query.resolution;
+    const resolutionFromQuery = r != null && Number.isFinite(r) && r > 0;
+    // Compute the auto fallback in milliseconds so a sub-second range
+    // doesn't truncate to a 0 ms divisor in the SQL bucketing.
+    const autoResolutionMs = Math.max(
+      1,
+      Math.round(
+        (to.toInstant().toEpochMilli() - from.toInstant().toEpochMilli()) / 500
+      )
+    );
+    const resolutionMs = resolutionFromQuery ? r * 1000 : autoResolutionMs;
 
     this.debug(
-      `[HistoryProvider] getValues: context=${context}, from=${from}, to=${to}, resolution=${resolution}ms, paths=${query.pathSpecs.length}`
+      `[HistoryProvider] getValues: context=${context}, from=${from}, to=${to}, resolution=${resolutionMs}ms (${resolutionFromQuery ? 'from query' : 'auto'}), paths=${query.pathSpecs.length}`
     );
 
     const fromIso = from.toInstant().toString();
@@ -175,7 +187,7 @@ export class HistoryProvider implements HistoryApi {
           pathSpec,
           fromIso,
           toIso,
-          resolution
+          resolutionMs
         );
         allData[pathSpec.path] = pathData;
       } catch (error) {


### PR DESCRIPTION
## Summary

The SignalK History API spec defines `resolution` as seconds:

> Length of data sample time window in seconds or as a time expression ('1s', '1m', '1h', '1d')

[signalk-server#2643](https://github.com/SignalK/signalk-server/pull/2643) (merged 2026-05-05) makes that explicit in the server: it now parses `?resolution=...` to a positive integer number of seconds before invoking the registered `HistoryApi` provider's `getValues(query)`.

This plugin's V2 implementation in `src/history-provider.ts` consumed `query.resolution` as-is and used it directly in the DuckDB bucketing SQL, which works in milliseconds:

```sql
EPOCH_MS(CAST(FLOOR(EPOCH_MS(signalk_timestamp::TIMESTAMP) / ${resolutionMs}) * ${resolutionMs} AS BIGINT))
```

So `?resolution=60` (1 minute per the spec) bucketed every 60 ms in V2 queries -- 1000x finer than intended. The fallback assignment right next to it (`Math.round((range_seconds) / 500 * 1000)`) was already in milliseconds, which both masked the issue when callers omitted `resolution` and confirmed that the SQL side is unambiguously ms.

## Change

Multiply `query.resolution` by 1000 at the boundary and rename the local from `resolution` to `resolutionMs` so the unit story is explicit:

```ts
const resolutionMs = query.resolution
  ? query.resolution * 1000
  : Math.round(((to.toEpochSecond() - from.toEpochSecond()) / 500) * 1000);
```

## Scope

- V2 path only (the `HistoryApi` provider registered via `app.registerHistoryApiProvider`).
- V1 (`/signalk/v1/history/...`) is unaffected: it parses the query string to ms via `parseResolutionToMillis` (see PR #59 for the spec-aligned parser).