### PR TITLE
feat(gpx-import): re-aggregate tiers for imported partitions

### DIFF
--- a/public/js/import.js
+++ b/public/js/import.js
@@ -21,6 +21,7 @@ const GPX_PHASE_LABEL = {
   scan: 'Finding files',
   parse: 'Reading files',
   write: 'Writing parquet',
+  aggregate: 'Building tiers',
 };
 
 function getSelectedGpxPaths() {
@@ -458,14 +459,29 @@ function updateGpxImportProgress(data) {
   const stats = document.getElementById('gpxImportStats');
 
   const phase = GPX_PHASE_LABEL[data.phase] || data.phase || '';
-  progressBar.style.width = `${data.percent}%`;
-  progressText.textContent =
-    `${data.percent}% complete (${data.processed}/${data.total} files` +
-    (phase ? `, ${phase.toLowerCase()}` : '') +
-    ')';
-  currentFile.textContent = data.currentFile
-    ? `Current: ${data.currentFile}`
-    : '';
+
+  if (data.phase === 'aggregate') {
+    // Switch the bar to date-based progress; the file-percent has already
+    // hit 100% by this phase and would otherwise sit frozen.
+    const aggDone = data.aggregationDatesProcessed || 0;
+    const aggTotal = data.aggregationDatesTotal || 0;
+    const aggPercent =
+      aggTotal > 0 ? Math.round((aggDone / aggTotal) * 100) : 0;
+    progressBar.style.width = `${aggPercent}%`;
+    progressText.textContent = `Building tiers: ${aggDone}/${aggTotal} dates (${aggPercent}%)`;
+    currentFile.textContent = data.aggregationCurrentDate
+      ? `Current date: ${data.aggregationCurrentDate}`
+      : '';
+  } else {
+    progressBar.style.width = `${data.percent}%`;
+    progressText.textContent =
+      `${data.percent}% complete (${data.processed}/${data.total} files` +
+      (phase ? `, ${phase.toLowerCase()}` : '') +
+      ')';
+    currentFile.textContent = data.currentFile
+      ? `Current: ${data.currentFile}`
+      : '';
+  }
   stats.textContent =
     `Points parsed: ${Number(data.pointsParsed).toLocaleString()} ` +
     `· Records written: ${Number(data.recordsWritten).toLocaleString()} ` +

--- a/src/api-routes.ts
+++ b/src/api-routes.ts
@@ -4304,6 +4304,9 @@ export function registerApiRoutes(
 
   // Created lazily in routes below so state.parquetWriter is available at
   // request time (not at plugin-start when the writer may not yet exist).
+  // aggregationService is captured by closure (declared further down in
+  // this same function) and is always initialized by the time any HTTP
+  // handler fires, so the const-after-use pattern is safe here.
   let gpxImportService: GpxImportService | undefined;
   const getGpxImportService = (): GpxImportService => {
     if (!state.parquetWriter) {
@@ -4312,7 +4315,11 @@ export function registerApiRoutes(
       );
     }
     if (!gpxImportService) {
-      gpxImportService = new GpxImportService(app, state.parquetWriter);
+      gpxImportService = new GpxImportService(
+        app,
+        state.parquetWriter,
+        aggregationService
+      );
     }
     return gpxImportService;
   };

--- a/src/services/gpx-import-service.ts
+++ b/src/services/gpx-import-service.ts
@@ -27,6 +27,7 @@ import { DataRecord, ParquetWriter } from '../types';
 import { HivePathBuilder } from '../utils/hive-path-builder';
 import { parseGpx, GpxPoint } from '../utils/gpx-parser';
 import { IMPORT_JOB_TTL_MS } from '../constants';
+import { AggregationService } from './aggregation-service';
 
 export type GpxImportPath =
   | 'navigation.position'
@@ -55,7 +56,7 @@ export interface GpxImportConfig {
 export interface GpxImportProgress {
   jobId: string;
   status: 'scanning' | 'running' | 'completed' | 'cancelled' | 'error';
-  phase: 'scan' | 'parse' | 'write';
+  phase: 'scan' | 'parse' | 'write' | 'aggregate';
   processed: number; // files processed
   total: number; // files to process
   percent: number;
@@ -71,6 +72,10 @@ export interface GpxImportProgress {
   filesSkipped: number;
   filesCreated: string[];
   errors: string[];
+  // Populated only during the post-write aggregation phase
+  aggregationDatesTotal?: number;
+  aggregationDatesProcessed?: number;
+  aggregationCurrentDate?: string;
 }
 
 export interface GpxScanResult {
@@ -94,16 +99,22 @@ export class GpxImportService {
   private readonly app: ServerAPI;
   private readonly parquetWriter: ParquetWriter;
   private readonly hivePathBuilder: HivePathBuilder;
+  private readonly aggregationService?: AggregationService;
 
   // Per-job cancellation. A set (rather than a single flag) so concurrent
   // imports don't trample each other's state — cancelling one job never
   // cancels another.
   private readonly cancelledJobs: Set<string> = new Set();
 
-  constructor(app: ServerAPI, parquetWriter: ParquetWriter) {
+  constructor(
+    app: ServerAPI,
+    parquetWriter: ParquetWriter,
+    aggregationService?: AggregationService
+  ) {
     this.app = app;
     this.parquetWriter = parquetWriter;
     this.hivePathBuilder = new HivePathBuilder();
+    this.aggregationService = aggregationService;
   }
 
   /**
@@ -233,6 +244,11 @@ export class GpxImportService {
 
       progress.status = 'running';
 
+      // Distinct (year, dayOfYear) partitions touched by this import,
+      // keyed by ISO YYYY-MM-DD. Drives the post-write aggregation phase
+      // so we only re-aggregate days we actually wrote raw files into.
+      const touchedDays = new Map<string, Date>();
+
       for (let i = 0; i < gpxFiles.length; i++) {
         if (this.cancelledJobs.has(jobId)) {
           progress.status = 'cancelled';
@@ -255,7 +271,8 @@ export class GpxImportService {
             resolvedContext,
             config,
             progress,
-            metadataCache
+            metadataCache,
+            touchedDays
           );
 
           if (imported) {
@@ -276,7 +293,26 @@ export class GpxImportService {
         }
       }
 
-      progress.status = 'completed';
+      // Aggregation phase: rebuild 5s/60s/1h tiers for every (year, day)
+      // partition we wrote into. Without this the daily auto-aggregation
+      // only covers yesterday, leaving historical imports stranded in raw.
+      // aggregateDate() is idempotent (DuckDB COPY ... TO overwrites the
+      // single per-day output file), so re-running for already-aggregated
+      // dates is safe.
+      if (
+        this.aggregationService &&
+        touchedDays.size > 0 &&
+        !this.cancelledJobs.has(jobId)
+      ) {
+        await this.runAggregationPhase(jobId, touchedDays, progress);
+      }
+
+      // Cancellation requested mid-aggregation is reported as cancelled,
+      // not completed; partial tier coverage is real and the caller
+      // should know.
+      progress.status = this.cancelledJobs.has(jobId)
+        ? 'cancelled'
+        : 'completed';
       progress.completedAt = new Date();
       scheduleImportJobCleanup(jobId);
     } catch (error) {
@@ -312,6 +348,10 @@ export class GpxImportService {
   /**
    * Parse a single GPX file and write its points to the parquet store.
    * Returns true if at least one parquet file was produced.
+   *
+   * `touchedDays` is mutated to record each (year, day) partition this
+   * file wrote into; the caller drives a post-import aggregation phase
+   * over that set.
    */
   private async importFile(
     jobId: string,
@@ -319,7 +359,8 @@ export class GpxImportService {
     resolvedContext: string,
     config: GpxImportConfig,
     progress: GpxImportProgress,
-    metadataCache: Map<string, object | undefined>
+    metadataCache: Map<string, object | undefined>,
+    touchedDays: Map<string, Date>
   ): Promise<boolean> {
     const xml = await fs.readFile(sourcePath, 'utf8');
     const parsed = parseGpx(xml);
@@ -407,6 +448,12 @@ export class GpxImportService {
         await fs.rename(tempFilePath, filePath);
         progress.filesCreated.push(filePath);
         progress.recordsWritten += group.records.length;
+        // Record only after a successful write so a failed group doesn't
+        // schedule aggregation for a partition we never produced.
+        const dayKey = group.anchor.toISOString().slice(0, 10);
+        if (!touchedDays.has(dayKey)) {
+          touchedDays.set(dayKey, group.anchor);
+        }
       } catch (error) {
         try {
           await fs.remove(tempFilePath);
@@ -418,6 +465,53 @@ export class GpxImportService {
     }
 
     return groups.size > 0;
+  }
+
+  /**
+   * Re-aggregate every (year, day) partition this import wrote into.
+   * `aggregateDate()` cascades raw -> 5s -> 60s -> 1h, and is idempotent
+   * (DuckDB COPY ... TO overwrites the per-day output file), so running
+   * it for already-aggregated dates is safe; it just refolds the new
+   * raw rows in alongside the existing ones.
+   *
+   * Errors per-date are recorded but don't fail the import; partial
+   * tier coverage is better than rejecting the whole job.
+   */
+  private async runAggregationPhase(
+    jobId: string,
+    touchedDays: Map<string, Date>,
+    progress: GpxImportProgress
+  ): Promise<void> {
+    if (!this.aggregationService) return;
+
+    progress.phase = 'aggregate';
+    progress.aggregationDatesTotal = touchedDays.size;
+    progress.aggregationDatesProcessed = 0;
+
+    // Stable order: YYYY-MM-DD sorts chronologically as a string.
+    const sortedDays = Array.from(touchedDays.entries()).sort(([a], [b]) =>
+      a.localeCompare(b)
+    );
+
+    let i = 0;
+    for (const [dateStr, date] of sortedDays) {
+      if (this.cancelledJobs.has(jobId)) return;
+
+      progress.aggregationCurrentDate = dateStr;
+      progress.aggregationDatesProcessed = i;
+
+      try {
+        await this.aggregationService.aggregateDate(date);
+      } catch (error) {
+        progress.errors.push(
+          `Aggregation failed for ${dateStr}: ${(error as Error).message}`
+        );
+      }
+      i++;
+    }
+
+    progress.aggregationDatesProcessed = touchedDays.size;
+    progress.aggregationCurrentDate = undefined;
   }
 
   private buildHiveFilePath(


### PR DESCRIPTION
## Summary

Historical GPX imports wrote raw parquet files but never triggered aggregation, so 5s/60s/1h tiers stayed empty for every imported day. The daily auto-aggregation only covers yesterday, and the existing migration flow has a `triggerAggregation` flag but the import flow had no equivalent. Result: with hundreds of imported days in raw, only the handful of recent live days had aggregated companions, breaking auto-tier history queries against historical data.

## Changes

- **`src/services/gpx-import-service.ts`** — Added a `Map<string, Date>` accumulator that records each (year, dayOfYear) partition successfully written during the import. After the file loop, a new `aggregate` phase iterates that set in chronological order and calls `AggregationService.aggregateDate` for each. Per-date errors are recorded in `progress.errors` but don't fail the job. Cancellation between dates is honored. Constructor now accepts an optional `AggregationService`.
- **`src/api-routes.ts`** — Pass the existing `aggregationService` instance through to `GpxImportService`. The const-after-use pattern is safe because the lazy factory only runs at HTTP request time (well after `registerApiRoutes` finishes); a comment documents this.
- **`public/js/import.js`** — New `aggregate` phase label and a date-based progress bar (file-percent has already hit 100% by this phase).

`aggregateDate` is idempotent (DuckDB `COPY ... TO` overwrites the per-day output file), so re-running it on partitions that already have aggregated data is safe and just refolds new raw rows in alongside existing ones.

## Test plan

- [x] `npm run build` clean.
- [x] ESLint clean on changed TS files; prettier clean on the lines I changed.
- [x] End-to-end against a disposable Docker SignalK with the worktree mounted: imported `sv_ona_gap_filler.gpx` (740 KB) and `sv_ona_full.gpx` (2.8 MB) via `POST /api/import/gpx`. Job progressed through `parse` → `write` → **`aggregate`** phases. 31,586 GPX points → 77,419 records, 457 distinct dates, 0 errors.
- [x] Store stats before vs. after: tiers went from `{raw:0, 5s:0, 60s:0, 1h:0}` to `{raw:1314, 5s:1311, 60s:1311, 1h:1311}`. Per-tier file count matches `(paths × active days)`. Three-file delta between raw and aggregated is from partitions where the schema check skipped object-typed data; aggregation logged no errors.
- [x] On-disk spot-check for one partition (2024-04-19) confirmed three per-path aggregated files (`signalk_data_2024-04-19_aggregated.parquet`) in each of `tier=5s`, `tier=60s`, `tier=1h` alongside the raw `signalk_data_gpx_*.parquet`.
- [x] Cancellation path verified by code review: existing file-loop cancel still returns early; new guard skips the aggregate phase when cancellation arrives between phases; mid-aggregation cancel exits the loop and the terminal status correctly reads `cancelled` instead of `completed`.