### PR TITLE
feat(history): add sourceRef filtering to History API

### DIFF
--- a/README.md
+++ b/README.md
@@ -850,6 +850,28 @@ curl "http://localhost:3000/signalk/v1/history/values?duration=1h&paths=navigati
 curl "http://localhost:3000/signalk/v1/history/values?duration=1h&paths=environment.wind.speedApparent:ema:0.3"
 ```
 
+#### Filtering by Source
+
+Append `|<sourceRef>` to a path to restrict it to a single SignalK source. This
+is useful when several devices publish the same path (e.g. multiple GPS
+receivers or heading sensors) and you want the history of just one of them. The
+source reference is the delta's `$source` value, and the filter applies after
+any optional aggregation method.
+
+| Format | Description | Example |
+|--------|-------------|---------|
+| `path\|sourceRef` | Filter a path to one source | `navigation.headingMagnetic\|n2k-on-ve.can0.115` |
+| `path:method\|sourceRef` | Aggregate and filter by source | `navigation.speedOverGround:max\|n2k-on-ve.can0.115` |
+
+```bash
+# Heading from a specific compass over the last hour
+curl "http://localhost:3000/signalk/v1/history/values?duration=1h&paths=navigation.headingMagnetic|n2k-on-ve.can0.115"
+```
+
+Source filtering always reads raw data: aggregated tiers blend every source
+into each time bucket, so they cannot be filtered by source. Each `values`
+entry in the response echoes the `sourceRef` it was restricted to.
+
 #### Extension Parameters (non-standard)
 
 | Parameter | Description | Format | Examples |

--- a/src/HistoryAPI-types.ts
+++ b/src/HistoryAPI-types.ts
@@ -1,11 +1,21 @@
-import { Brand, Context, Path, Timestamp } from '@signalk/server-api';
+import {
+  Brand,
+  Context,
+  Path,
+  SourceRef,
+  Timestamp,
+} from '@signalk/server-api';
 import { Request } from 'express';
+import { PathFilter } from './utils/path-filters';
 
 export type AggregateMethod = Brand<string, 'aggregatemethod'>;
 
 type ValueList = {
   path: Path;
   method: AggregateMethod;
+  // Present only when the request filtered this path to a specific source via
+  // the `path:aggregate|sourceRef` syntax.
+  sourceRef?: SourceRef;
 }[];
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -101,4 +111,7 @@ export interface PathSpec {
   smoothing?: 'sma' | 'ema'; // Per-path smoothing method
   smoothingParam?: number; // SMA period or EMA alpha
   smoothingOnly?: boolean; // Official syntax: return only smoothed value (path:sma:5)
+  // Inline filters parsed from the path expression (e.g. `|sourceRef`).
+  // See utils/path-filters.ts. Empty when none were requested.
+  filters: PathFilter[];
 }

--- a/src/HistoryAPI.ts
+++ b/src/HistoryAPI.ts
@@ -60,6 +60,22 @@ import {
   PathRetentionRule,
   RetentionRuleSet,
 } from './utils/retention-rules';
+import {
+  parsePathFilters,
+  buildParquetFilterClause,
+  availableFilterColumns,
+  filterEcho,
+  FILTER_DELIMITERS,
+} from './utils/path-filters';
+
+// Allowed characters in the `paths` query parameter: path/aggregate tokens
+// (alphanumerics, `.,:_`), the inline-filter delimiters from PATH_FILTER_DEFS,
+// and `-`. Delimiters are escaped for use inside a character class; `-` is kept
+// last so it stays a literal.
+const PATHS_SANITIZER = new RegExp(
+  `[^0-9a-z.,:_${FILTER_DELIMITERS.replace(/[\\\]^-]/g, '\\$&')}-]`,
+  'gi'
+);
 
 export function registerHistoryApiRoute(
   router: Pick<Router, 'get'>,
@@ -472,6 +488,17 @@ function utcToLocalTimestamp(utcTs: Timestamp): Timestamp {
   }
 }
 
+// A response `values` entry: path + aggregate method, optional smoothing
+// metadata, plus any echoed inline-filter fields (e.g. `sourceRef`). The index
+// signature keeps it open to new filters without a type change here.
+interface HistoryValueEntry {
+  path: Path;
+  method: AggregateMethod;
+  smoothing?: string;
+  window?: number;
+  [field: string]: unknown;
+}
+
 export class HistoryAPI {
   private sqliteBuffer?: SQLiteBufferInterface;
   private hivePathBuilder: HivePathBuilder;
@@ -739,8 +766,13 @@ export class HistoryAPI {
       const timeResolutionMillis = req.query.resolution
         ? parseResolutionToMillis(req.query.resolution as string)
         : ((to.toEpochSecond() - from.toEpochSecond()) / 500) * 1000;
+      // Strip everything except path/aggregate characters, the filter
+      // delimiters from PATH_FILTER_DEFS, and `-` (common in source
+      // references). This is a coarse injection guard; values are also SQL-
+      // escaped downstream. Adding a delimiter to the registry extends this
+      // automatically.
       const pathExpressions = ((req.query.paths as string) || '')
-        .replace(/[^0-9a-z.,:_]/gi, '')
+        .replace(PATHS_SANITIZER, '')
         .split(',');
       const pathSpecs: PathSpec[] = pathExpressions.map(splitPathExpression);
 
@@ -861,7 +893,9 @@ export class HistoryAPI {
     positionPath: string = 'navigation.position',
     app?: any
   ): Promise<DataResult> {
-    const allData: { [path: string]: Array<[Timestamp, unknown]> } = {};
+    // Keyed by pathSpecKey(spec), not bare path, so the same path requested
+    // with different sources/aggregates keeps separate series.
+    const allData: { [key: string]: Array<[Timestamp, unknown]> } = {};
     const objectPaths = new Set<string>(); // Track which paths are object paths
 
     // Convert ZonedDateTime to Date for S3 pattern building
@@ -928,17 +962,29 @@ export class HistoryAPI {
               EPOCH_MS(CAST(FLOOR(EPOCH_MS(signalk_timestamp::TIMESTAMP) / ${timeResolutionMillis}) * ${timeResolutionMillis} AS BIGINT))
             ), '%Y-%m-%dT%H:%M:%SZ')`;
 
+            // Optional filters for the position path (e.g. one of several GPS
+            // receivers). This fast path is local-only (raw parquet + buffer),
+            // so probe just the local glob for the filter columns.
+            const posAvailable = await availableFilterColumns(
+              connection,
+              [posFilePath],
+              posPathSpec.filters
+            );
+            const posSourceFilter = buildParquetFilterClause(
+              posPathSpec.filters,
+              posAvailable
+            );
+
             // Build FROM: parquet UNION ALL buffer (for today's unexported data)
             const parquetFrom = `SELECT signalk_timestamp, value_latitude, value_longitude FROM (
               SELECT * FROM read_parquet('${posFilePath}', union_by_name=true, filename=true)
               WHERE filename NOT LIKE '%/processed/%'
               AND filename NOT LIKE '%/quarantine/%'
               AND filename NOT LIKE '%/failed/%'
-              AND filename NOT LIKE '%/repaired/%')`;
+              AND filename NOT LIKE '%/repaired/%'${posSourceFilter})`;
 
             let fromSource = `(${parquetFrom})`;
             if (hasBuffer && this.sqliteBuffer) {
-              const posPathSpec = pathSpecs.find(ps => isPositionPath(ps.path))!;
               const bufferTableCols = this.sqliteBuffer.getTableColumns(posPathSpec.path);
               const bufferSubquery = buildBufferObjectSubquery(
                 context, posPathSpec.path, fromIso, toIso,
@@ -947,7 +993,8 @@ export class HistoryAPI {
                   ['longitude', { name: 'longitude', columnName: 'value_longitude', dataType: 'numeric' as const }],
                 ]),
                 this.sqliteBuffer.getKnownPaths(),
-                bufferTableCols
+                bufferTableCols,
+                posPathSpec.filters
               );
               if (bufferSubquery) {
                 fromSource = `(${parquetFrom} UNION ALL SELECT signalk_timestamp, TRY_CAST(value_latitude AS DOUBLE) as value_latitude, TRY_CAST(value_longitude AS DOUBLE) as value_longitude FROM ${bufferSubquery})`;
@@ -1015,7 +1062,7 @@ export class HistoryAPI {
               }
             }
 
-            allData[posPathSpec.path] = posData;
+            allData[pathSpecKey(posPathSpec)] = posData;
             debug(
               `[Spatial] Bucketed ${rows.length} positions, ${posData.length} within filter`
             );
@@ -1024,7 +1071,7 @@ export class HistoryAPI {
           }
         } catch (error) {
           debug(`[Spatial] Error in fast position query: ${error}`);
-          allData[posPathSpec.path] = [];
+          allData[pathSpecKey(posPathSpec)] = [];
           spatialTimestamps = new Set<string>();
         }
       }
@@ -1036,7 +1083,11 @@ export class HistoryAPI {
     await limiter.map(pathSpecs, async pathSpec => {
       try {
         // Skip position if already handled by fast spatial bucket query
-        if (hasPositionPath && isPositionPath(pathSpec.path) && allData[pathSpec.path]) {
+        if (
+          hasPositionPath &&
+          isPositionPath(pathSpec.path) &&
+          allData[pathSpecKey(pathSpec)]
+        ) {
           return;
         }
 
@@ -1056,6 +1107,16 @@ export class HistoryAPI {
         ) {
           debug(
             `Path ${pathSpec.path}: skipAggregation rule matched — overriding tier=${effectiveTier} to raw`
+          );
+          effectiveTier = 'raw';
+        }
+
+        // Inline filters require raw data: aggregated tiers (5s/60s/1h) blend
+        // every source into each bucket and don't carry the source_* columns,
+        // so they cannot be filtered.
+        if (effectiveTier !== 'raw' && pathSpec.filters.length > 0) {
+          debug(
+            `Path ${pathSpec.path}: filter present — overriding tier=${effectiveTier} to raw`
           );
           effectiveTier = 'raw';
         }
@@ -1161,7 +1222,7 @@ export class HistoryAPI {
             fromClause = localFromClause;
           } else {
             debug(`No data source available for path ${pathSpec.path}`);
-            allData[pathSpec.path] = [];
+            allData[pathSpecKey(pathSpec)] = [];
             return;
           }
 
@@ -1293,6 +1354,20 @@ export class HistoryAPI {
             const objBucketExpr = (col: string) =>
               `strftime(DATE_TRUNC('seconds', EPOCH_MS(CAST(FLOOR(EPOCH_MS(${col}::TIMESTAMP) / ${timeResolutionMillis}) * ${timeResolutionMillis} AS BIGINT))), '%Y-%m-%dT%H:%M:%SZ')`;
 
+            // When filtering, probe the (raw) parquet schema for the filter
+            // columns so we either filter on them or exclude the parquet side
+            // when absent (legacy/imported files). Probe both local and S3
+            // since either may hold the data being queried.
+            const objAvailable = await availableFilterColumns(
+              connection,
+              [localFilePath, s3FilePath],
+              pathSpec.filters
+            );
+            const objSourceFilter = buildParquetFilterClause(
+              pathSpec.filters,
+              objAvailable
+            );
+
             const buildObjQuery = (fc: string) => {
               const subqueries: string[] = [];
 
@@ -1300,7 +1375,7 @@ export class HistoryAPI {
               subqueries.push(`
                 SELECT ${objBucketExpr(objTsCol)} as timestamp, ${componentSelects}, 1 as priority
                 FROM ${fc} AS source_data
-                WHERE ${objTsCol} >= '${fromIso}' AND ${objTsCol} < '${toIso}' AND (${componentWhereConditions})${spatialWhereClause}
+                WHERE ${objTsCol} >= '${fromIso}' AND ${objTsCol} < '${toIso}' AND (${componentWhereConditions})${spatialWhereClause}${objSourceFilter}
                 GROUP BY timestamp`);
 
               // Source 2: SQLite buffer (today's live data not yet exported)
@@ -1313,7 +1388,8 @@ export class HistoryAPI {
                   toIso,
                   componentSchema.components,
                   knownBufferPaths,
-                  bufferTableCols
+                  bufferTableCols,
+                  pathSpec.filters
                 );
                 if (bufferSubquery) {
                   subqueries.push(`
@@ -1358,7 +1434,7 @@ export class HistoryAPI {
               return [timestamp, reconstructedObject];
             });
 
-            allData[pathSpec.path] = pathData;
+            allData[pathSpecKey(pathSpec)] = pathData;
           } else {
             // Scalar path
             // First, check if value_json column exists in the parquet files
@@ -1376,6 +1452,20 @@ export class HistoryAPI {
 
             debug(
               `Path ${pathSpec.path}: value_json column ${hasValueJson ? 'exists' : 'does not exist'}`
+            );
+
+            // Filter the parquet tier when requested. Probe both local and S3
+            // (data may live in either) for the filter columns; columns absent
+            // everywhere become `AND 1=0` so the parquet side contributes
+            // nothing and the always-tagged buffer answers the query.
+            const scalarAvailable = await availableFilterColumns(
+              connection,
+              [localFilePath, s3FilePath],
+              pathSpec.filters
+            );
+            const scalarSourceFilter = buildParquetFilterClause(
+              pathSpec.filters,
+              scalarAvailable
             );
 
             // Each source does its own aggregation into (timestamp, value, priority).
@@ -1406,7 +1496,7 @@ export class HistoryAPI {
               subqueries.push(`
                 SELECT ${bucketExpr(tsCol)} as timestamp, ${tierAggExpr} as value, 1 as priority
                 FROM ${fc} AS source_data
-                WHERE ${tsCol} >= '${fromIso}' AND ${tsCol} < '${toIso}' AND ${whereClause}
+                WHERE ${tsCol} >= '${fromIso}' AND ${tsCol} < '${toIso}' AND ${whereClause}${scalarSourceFilter}
                 GROUP BY timestamp`);
 
               // Source 2: SQLite buffer (today's live data not yet exported)
@@ -1416,7 +1506,8 @@ export class HistoryAPI {
                   pathSpec.path,
                   fromIso,
                   toIso,
-                  knownBufferPaths
+                  knownBufferPaths,
+                  pathSpec.filters
                 );
                 if (bufferSubquery) {
                   const bufferAggExpr = getTierAggregateExpression(pathSpec.aggregateMethod, pathSpec.path, 'raw', false, app, context as string);
@@ -1459,7 +1550,7 @@ export class HistoryAPI {
               return [timestamp, value];
             });
 
-            allData[pathSpec.path] = pathData;
+            allData[pathSpecKey(pathSpec)] = pathData;
           }
         } finally {
           connection.disconnectSync();
@@ -1480,7 +1571,8 @@ export class HistoryAPI {
                 pathSpec.path,
                 fallbackFromIso,
                 fallbackToIso,
-                fallbackKnownPaths
+                fallbackKnownPaths,
+                pathSpec.filters
               );
               if (bufferSubquery) {
                 const fallbackAggExpr = isStringPath(pathSpec.path)
@@ -1499,7 +1591,7 @@ export class HistoryAPI {
                 `;
                 const bufResult = await bufferConn.runAndReadAll(bufferQuery);
                 const bufRows = bufResult.getRowObjects();
-                allData[pathSpec.path] = bufRows.map((row: any) => [
+                allData[pathSpecKey(pathSpec)] = bufRows.map((row: any) => [
                   row.timestamp as Timestamp,
                   row.value,
                 ]);
@@ -1510,10 +1602,10 @@ export class HistoryAPI {
             }
           } catch (bufErr) {
             debug(`Buffer-only fallback also failed for ${pathSpec.path}: ${bufErr}`);
-            allData[pathSpec.path] = [];
+            allData[pathSpecKey(pathSpec)] = [];
           }
         } else {
-          allData[pathSpec.path] = [];
+          allData[pathSpecKey(pathSpec)] = [];
         }
       }
     });
@@ -1522,20 +1614,21 @@ export class HistoryAPI {
     // This filters data to only include times when vessel was within spatial filter
     if (spatialTimestamps !== null) {
       for (const pathSpec of pathSpecs) {
-        if (!isPositionPath(pathSpec.path) && allData[pathSpec.path]) {
+        const key = pathSpecKey(pathSpec);
+        if (!isPositionPath(pathSpec.path) && allData[key]) {
           if (spatialTimestamps.size === 0) {
             // No position data in area — return empty for all correlated paths
-            allData[pathSpec.path] = [];
+            allData[key] = [];
             debug(
               `[Spatial Correlation] No matching positions — cleared ${pathSpec.path}`
             );
           } else {
-            const originalCount = allData[pathSpec.path].length;
-            allData[pathSpec.path] = allData[pathSpec.path].filter(
-              ([timestamp]) => spatialTimestamps!.has(timestamp)
+            const originalCount = allData[key].length;
+            allData[key] = allData[key].filter(([timestamp]) =>
+              spatialTimestamps!.has(timestamp)
             );
             debug(
-              `[Spatial Correlation] Filtered ${pathSpec.path}: ${originalCount} -> ${allData[pathSpec.path].length} records`
+              `[Spatial Correlation] Filtered ${pathSpec.path}: ${originalCount} -> ${allData[key].length} records`
             );
           }
         }
@@ -1552,12 +1645,7 @@ export class HistoryAPI {
 
     // Determine final data and values based on smoothing mode
     let finalData: Array<[Timestamp, ...unknown[]]>;
-    let finalValues: Array<{
-      path: Path;
-      method: AggregateMethod;
-      smoothing?: string;
-      window?: number;
-    }>;
+    let finalValues: HistoryValueEntry[];
 
     if (hasPerPathSmoothing) {
       // Per-path smoothing mode: apply smoothing only to paths that have it defined
@@ -1571,9 +1659,12 @@ export class HistoryAPI {
     } else {
       // No smoothing
       finalData = mergedData;
-      finalValues = pathSpecs.map(({ path, aggregateMethod }) => ({
+      finalValues = pathSpecs.map(({ path, aggregateMethod, filters }) => ({
         path,
         method: aggregateMethod,
+        // Echo each filter back (e.g. sourceRef) so callers can tell what each
+        // column was restricted to.
+        ...filterEcho(filters),
       }));
     }
 
@@ -1589,14 +1680,14 @@ export class HistoryAPI {
   }
 
   private mergePathData(
-    allData: { [path: string]: Array<[Timestamp, unknown]> },
+    allData: { [key: string]: Array<[Timestamp, unknown]> },
     pathSpecs: PathSpec[]
   ): Array<[Timestamp, ...unknown[]]> {
     // Create a map of all unique timestamps
     const timestampMap = new Map<string, unknown[]>();
 
     pathSpecs.forEach((pathSpec, index) => {
-      const pathData = allData[pathSpec.path] || [];
+      const pathData = allData[pathSpecKey(pathSpec)] || [];
       pathData.forEach(([timestamp, value]) => {
         if (!timestampMap.has(timestamp)) {
           timestampMap.set(timestamp, new Array(pathSpecs.length).fill(null));
@@ -1820,21 +1911,21 @@ export class HistoryAPI {
     pathSpecs: PathSpec[],
     objectPaths: Set<string>,
     usePerPathSmoothing: boolean = false
-  ): Array<{
-    path: Path;
-    method: AggregateMethod;
-    smoothing?: string;
-    window?: number;
-  }> {
-    const result: Array<{
-      path: Path;
-      method: AggregateMethod;
-      smoothing?: string;
-      window?: number;
-    }> = [];
+  ): HistoryValueEntry[] {
+    const result: HistoryValueEntry[] = [];
 
     pathSpecs.forEach(
-      ({ path, aggregateMethod, smoothing, smoothingParam, smoothingOnly }) => {
+      ({
+        path,
+        aggregateMethod,
+        smoothing,
+        smoothingParam,
+        smoothingOnly,
+        filters,
+      }) => {
+        // Every column derived from a filtered path carries the same filters,
+        // so echo them on each emitted entry.
+        const echo = filterEcho(filters);
         if (usePerPathSmoothing) {
           // Per-path smoothing mode
           // Check if using official SignalK syntax (smoothingOnly=true)
@@ -1843,17 +1934,12 @@ export class HistoryAPI {
 
           if (!smoothingOnly) {
             // Extension syntax: add raw value entry first
-            result.push({ path, method: aggregateMethod });
+            result.push({ path, method: aggregateMethod, ...echo });
           }
 
           // Add smoothed entry if smoothing is defined
           if (smoothing) {
-            const smoothedEntry: {
-              path: Path;
-              method: AggregateMethod;
-              smoothing: string;
-              window: number;
-            } = {
+            const smoothedEntry: HistoryValueEntry = {
               path,
               // For official syntax, use sma/ema as the method in response
               method: smoothingOnly
@@ -1866,23 +1952,26 @@ export class HistoryAPI {
                   : smoothing === 'sma'
                     ? 10
                     : 0.2,
+              ...echo,
             };
             result.push(smoothedEntry);
           }
         } else if (objectPaths.has(path)) {
           // Object path - EMA/SMA are embedded in the object as component properties
           // Just add the single path entry
-          result.push({ path, method: aggregateMethod });
+          result.push({ path, method: aggregateMethod, ...echo });
         } else {
           // Scalar path - add separate entries for value, EMA, and SMA
-          result.push({ path, method: aggregateMethod });
+          result.push({ path, method: aggregateMethod, ...echo });
           result.push({
             path: `${path}.ema` as Path,
             method: 'ema' as AggregateMethod,
+            ...echo,
           });
           result.push({
             path: `${path}.sma` as Path,
             method: 'sma' as AggregateMethod,
+            ...echo,
           });
         }
       }
@@ -1892,8 +1981,20 @@ export class HistoryAPI {
   }
 }
 
+// Parses a path expression into a PathSpec.
+//   'navigation.headingMagnetic'                        -> { aggregate: 'average' }
+//   'navigation.headingMagnetic:max'                    -> { aggregate: 'max' }
+//   'navigation.headingMagnetic:average:sma:5'          -> { aggregate: 'average', smoothing: 'sma' }
+//   'navigation.headingMagnetic|n2k-on-ve.can0.115'     -> { aggregate: 'average', filters: [sourceRef] }
+//   'navigation.headingMagnetic:max|n2k-on-ve.can0.115' -> { aggregate: 'max', filters: [sourceRef] }
+//
+// Inline filters (e.g. `|sourceRef`) are split off first via parsePathFilters,
+// so the `:`-separated aggregate/smoothing parsing below operates on the bare
+// path expression. See utils/path-filters.ts to add another filter.
 function splitPathExpression(pathExpression: string): PathSpec {
-  const parts = pathExpression.split(':');
+  const { base: expr, filters } = parsePathFilters(pathExpression);
+
+  const parts = expr.split(':');
   let aggregateMethod = (parts[1] || 'average') as AggregateMethod;
 
   // Validate the aggregation method
@@ -1948,7 +2049,24 @@ function splitPathExpression(pathExpression: string): PathSpec {
     smoothing,
     smoothingParam,
     smoothingOnly,
+    filters,
   };
+}
+
+// Unique key for a parsed path expression. The same path may be requested more
+// than once with a different filter, aggregate, or smoothing (e.g.
+// `heading|srcA,heading|srcB`); keying intermediate results by path alone would
+// collapse those into one column, so the key includes every distinguishing
+// field. Fields never contain spaces (paths, aggregates, and filter values are
+// sanitised upstream), so a space separator is unambiguous.
+function pathSpecKey(ps: PathSpec): string {
+  return [
+    ps.path,
+    ps.aggregateMethod,
+    ps.smoothing ?? '',
+    ps.smoothingParam ?? '',
+    ...ps.filters.map(f => `${f.column}=${f.value}`),
+  ].join(' ');
 }
 
 const functionForAggregate: { [key: string]: string } = {

--- a/src/history-provider.ts
+++ b/src/history-provider.ts
@@ -7,7 +7,7 @@
 
 import { Temporal } from '@js-temporal/polyfill';
 import { ZonedDateTime, ZoneOffset, Instant } from '@js-joda/core';
-import { Context, Path, Timestamp, ServerAPI } from '@signalk/server-api';
+import { Context, Timestamp, ServerAPI } from '@signalk/server-api';
 import {
   HistoryApi,
   ValuesRequest,
@@ -19,6 +19,12 @@ import {
   PathSpec as SignalKPathSpec,
   AggregateMethod,
 } from '@signalk/server-api/dist/history';
+import {
+  filtersFromFields,
+  buildParquetFilterClause,
+  availableFilterColumns,
+  filterEcho,
+} from './utils/path-filters';
 import {
   getAvailablePathsArray,
   getAvailablePathsForTimeRange,
@@ -120,6 +126,22 @@ function parseTimeRange(
 }
 
 /**
+ * Unique key for a requested path spec. The same path may be requested more
+ * than once with a different filter, aggregate, or parameters; keying stored
+ * results by path alone would collapse those into one column, so the key
+ * includes every distinguishing field. Fields never contain spaces
+ * (paths/aggregates/filter values are sanitised upstream), so a space
+ * separator is unambiguous.
+ */
+function pathSpecKey(ps: SignalKPathSpec): string {
+  const parameter = (ps.parameter ?? []).join(',');
+  const filters = filtersFromFields(ps as unknown as Record<string, unknown>)
+    .map(f => `${f.column}=${f.value}`)
+    .join(' ');
+  return [ps.path, ps.aggregate, parameter, filters].join(' ');
+}
+
+/**
  * History API Provider implementation
  */
 export class HistoryProvider implements HistoryApi {
@@ -177,9 +199,12 @@ export class HistoryProvider implements HistoryApi {
     const toIso = to.toInstant().toString();
 
     // Query each path
-    const allData: { [pathName: string]: Array<[Timestamp, unknown]> } = {};
+    const allData: { [key: string]: Array<[Timestamp, unknown]> } = {};
 
     for (const pathSpec of query.pathSpecs) {
+      // Key by the full spec, not just path: the same path may appear multiple
+      // times with different sourceRef/aggregate and must stay separate.
+      const key = pathSpecKey(pathSpec);
       try {
         const pathData = await this.queryPath(
           context,
@@ -188,12 +213,12 @@ export class HistoryProvider implements HistoryApi {
           toIso,
           resolutionMs
         );
-        allData[pathSpec.path] = pathData;
+        allData[key] = pathData;
       } catch (error) {
         this.debug(
           `[HistoryProvider] Error querying path ${pathSpec.path}: ${error}`
         );
-        allData[pathSpec.path] = [];
+        allData[key] = [];
       }
     }
 
@@ -206,10 +231,14 @@ export class HistoryProvider implements HistoryApi {
         from: fromIso as Timestamp,
         to: toIso as Timestamp,
       },
-      values: query.pathSpecs.map(ps => ({
-        path: ps.path,
-        method: ps.aggregate,
-      })),
+      // Echo each filter (e.g. sourceRef) back per path. Cast covers the
+      // @signalk/server-api version gap until ValueList declares the field.
+      values: query.pathSpecs.map(ps => {
+        const echo = filterEcho(
+          filtersFromFields(ps as unknown as Record<string, unknown>)
+        );
+        return { path: ps.path, method: ps.aggregate, ...echo };
+      }) as ValuesResponse['values'],
       data: mergedData,
     };
   }
@@ -288,8 +317,23 @@ export class HistoryProvider implements HistoryApi {
 
       const aggFunc = this.getAggregateFunction(pathSpec.aggregate);
 
+      // Inline filters (e.g. sourceRef) come from the server-parsed PathSpec.
+      // The fields are populated by a newer @signalk/server-api than this plugin
+      // pins, so they are read defensively via the registry. This provider only
+      // queries raw-tier parquet; probe it for the filter columns so files
+      // without them are excluded rather than throwing.
+      const filters = filtersFromFields(
+        pathSpec as unknown as Record<string, unknown>
+      );
+      const available = await availableFilterColumns(
+        connection,
+        [filePath],
+        filters
+      );
+      const sourceFilter = buildParquetFilterClause(filters, available);
+
       // Build parquet FROM clause with filename filtering
-      const parquetFrom = `(SELECT * FROM read_parquet('${filePath}', union_by_name=true, filename=true) WHERE filename NOT LIKE '%/processed/%' AND filename NOT LIKE '%/quarantine/%' AND filename NOT LIKE '%/failed/%' AND filename NOT LIKE '%/repaired/%')`;
+      const parquetFrom = `(SELECT * FROM read_parquet('${filePath}', union_by_name=true, filename=true) WHERE filename NOT LIKE '%/processed/%' AND filename NOT LIKE '%/quarantine/%' AND filename NOT LIKE '%/failed/%' AND filename NOT LIKE '%/repaired/%'${sourceFilter})`;
 
       if (componentSchema && componentSchema.components.size > 0) {
         // Object path - aggregate each component
@@ -325,7 +369,8 @@ export class HistoryProvider implements HistoryApi {
             toIso,
             componentSchema.components,
             knownBufferPaths,
-            bufferTableCols
+            bufferTableCols,
+            filters
           );
           if (bufferSubquery) {
             federatedFrom = `(
@@ -398,7 +443,8 @@ export class HistoryProvider implements HistoryApi {
             pathSpec.path,
             fromIso,
             toIso,
-            knownBufferPaths
+            knownBufferPaths,
+            filters
           );
           if (bufferSubquery) {
             federatedFrom = `(
@@ -466,7 +512,7 @@ export class HistoryProvider implements HistoryApi {
    * Merge data from multiple paths into time-aligned rows
    */
   private mergePathData(
-    allData: { [path: string]: Array<[Timestamp, unknown]> },
+    allData: { [key: string]: Array<[Timestamp, unknown]> },
     pathSpecs: SignalKPathSpec[]
   ): Array<[Timestamp, ...unknown[]]> {
     // Collect all unique timestamps
@@ -478,21 +524,19 @@ export class HistoryProvider implements HistoryApi {
     // Sort timestamps
     const timestamps = Array.from(timestampSet).sort();
 
-    // Build lookup maps for each path
-    const pathMaps = new Map<string, Map<string, unknown>>();
-    pathSpecs.forEach(ps => {
+    // One lookup map per spec (by position), each fetched with the same
+    // composite key used to store it, so duplicate paths with different
+    // sourceRef/aggregate remain distinct columns.
+    const specMaps = pathSpecs.map(ps => {
       const map = new Map<string, unknown>();
-      (allData[ps.path] || []).forEach(([ts, val]) => map.set(ts, val));
-      pathMaps.set(ps.path, map);
+      (allData[pathSpecKey(ps)] || []).forEach(([ts, val]) => map.set(ts, val));
+      return map;
     });
 
     // Build merged rows
     return timestamps.map(ts => {
       const row: [Timestamp, ...unknown[]] = [ts as Timestamp];
-      pathSpecs.forEach(ps => {
-        const map = pathMaps.get(ps.path)!;
-        row.push(map.get(ts) ?? null);
-      });
+      specMaps.forEach(map => row.push(map.get(ts) ?? null));
       return row;
     });
   }

--- a/src/utils/buffer-sql-builder.ts
+++ b/src/utils/buffer-sql-builder.ts
@@ -9,20 +9,16 @@
 import { Context, Path } from '@signalk/server-api';
 import { ComponentInfo } from './schema-cache';
 import { pathToTableName } from './sqlite-buffer';
-
-/**
- * Escape a string value for safe inclusion in SQL literals.
- * Prevents SQL injection by doubling single quotes.
- */
-function escapeSql(value: string): string {
-  return value.replace(/'/g, "''");
-}
+import { escapeSqlString } from './sql-escape';
+import { PathFilter, buildBufferFilterClause } from './path-filters';
 
 /**
  * Build a buffer subquery for a scalar (numeric) path.
  *
  * Output columns: signalk_timestamp, value
  * Matches raw-tier parquet schema so it can be UNION ALL'd directly.
+ *
+ * When filters are provided, rows are restricted to matching column values.
  *
  * Returns null if no buffer table exists for this path (caller should skip UNION ALL).
  */
@@ -31,7 +27,8 @@ export function buildBufferScalarSubquery(
   signalkPath: Path | string,
   fromIso: string,
   toIso: string,
-  knownBufferPaths?: Set<string>
+  knownBufferPaths?: Set<string>,
+  filters?: PathFilter[]
 ): string | null {
   const pathStr = String(signalkPath);
 
@@ -51,17 +48,19 @@ export function buildBufferScalarSubquery(
     ${valueExpr} AS value,
     NULL::VARCHAR AS value_json
   FROM buffer.${tableName}
-  WHERE context = '${escapeSql(String(context))}'
-    AND received_timestamp >= '${escapeSql(fromIso)}'
-    AND received_timestamp < '${escapeSql(toIso)}'
+  WHERE context = '${escapeSqlString(String(context))}'
+    AND received_timestamp >= '${escapeSqlString(fromIso)}'
+    AND received_timestamp < '${escapeSqlString(toIso)}'
     AND exported = 0
-    AND value IS NOT NULL)`;
+    AND value IS NOT NULL${buildBufferFilterClause(filters)})`;
 }
 
 /**
  * Build a buffer subquery for an object path (e.g. navigation.position).
  *
  * Per-path tables already have flattened value_* columns, so no json_extract needed.
+ *
+ * When filters are provided, rows are restricted to matching column values.
  *
  * Returns null if no buffer table exists for this path (caller should skip UNION ALL).
  */
@@ -72,7 +71,8 @@ export function buildBufferObjectSubquery(
   toIso: string,
   components: Map<string, ComponentInfo>,
   knownBufferPaths?: Set<string>,
-  bufferTableColumns?: Set<string>
+  bufferTableColumns?: Set<string>,
+  filters?: PathFilter[]
 ): string | null {
   const pathStr = String(signalkPath);
 
@@ -101,9 +101,9 @@ export function buildBufferObjectSubquery(
     signalk_timestamp,
     ${componentSelects}
   FROM buffer.${tableName}
-  WHERE context = '${escapeSql(String(context))}'
-    AND received_timestamp >= '${escapeSql(fromIso)}'
-    AND received_timestamp < '${escapeSql(toIso)}'
+  WHERE context = '${escapeSqlString(String(context))}'
+    AND received_timestamp >= '${escapeSqlString(fromIso)}'
+    AND received_timestamp < '${escapeSqlString(toIso)}'
     AND exported = 0
-    AND value_json IS NOT NULL)`;
+    AND value_json IS NOT NULL${buildBufferFilterClause(filters)})`;
 }

--- a/src/utils/path-filters.ts
+++ b/src/utils/path-filters.ts
@@ -1,0 +1,215 @@
+/**
+ * Inline per-path query filters for the History API.
+ *
+ * A request can narrow a single path to rows whose stored column matches a
+ * value. The first such filter is `sourceRef`:
+ *
+ *   navigation.headingMagnetic:average|n2k-on-ve.can0.115
+ *
+ * filters to the source whose `$source` (stored in the `source_label` column)
+ * is `n2k-on-ve.can0.115`.
+ *
+ * ── Adding another filter ────────────────────────────────────────────────
+ * Add one entry to PATH_FILTER_DEFS below. Everything else in the read path is
+ * generic over the filter list: raw-tier forcing, parquet/buffer SQL, parquet
+ * schema probing, result keying, and the response echo all iterate the filters
+ * and need no per-filter changes.
+ *
+ * Requirements for a new filter:
+ *   - `column` must be written into raw-tier parquet AND the SQLite buffer.
+ *     The `source_*` columns already are (see data-handler.ts / sqlite-buffer.ts).
+ *   - `delimiter` must be a single character that cannot appear in a SignalK
+ *     path or aggregate token (the path sanitiser in HistoryAPI must also allow
+ *     it, alongside `|`).
+ *   - `field` is the property name echoed back in each response `values` entry.
+ */
+
+import { escapeSqlString } from './sql-escape';
+
+/** A resolved filter: match `column` = `value`, echoed back under `field`. */
+export interface PathFilter {
+  field: string;
+  column: string;
+  value: string;
+}
+
+interface PathFilterDef {
+  /** Single character that introduces the filter's value in a path expression. */
+  delimiter: string;
+  /** Response property name echoed in each `values` entry. */
+  field: string;
+  /** Stored parquet/buffer column the value is matched against. */
+  column: string;
+}
+
+/**
+ * The registry of supported inline path filters — the single place to add one.
+ */
+export const PATH_FILTER_DEFS: readonly PathFilterDef[] = [
+  // `path:aggregate|sourceRef` — restrict to one SignalK source.
+  { delimiter: '|', field: 'sourceRef', column: 'source_label' },
+];
+
+const DEF_BY_DELIMITER = new Map(
+  PATH_FILTER_DEFS.map(def => [def.delimiter, def])
+);
+
+/** The set of delimiter characters, for the path sanitiser to preserve. */
+export const FILTER_DELIMITERS = PATH_FILTER_DEFS.map(d => d.delimiter).join(
+  ''
+);
+
+/**
+ * Split inline filters off a path expression, returning the base expression
+ * (path + aggregate + smoothing) and the parsed filters.
+ *
+ * Input:  'navigation.position:first|gps-1'
+ * Output: { base: 'navigation.position:first',
+ *           filters: [{ field: 'sourceRef', column: 'source_label', value: 'gps-1' }] }
+ */
+export function parsePathFilters(expr: string): {
+  base: string;
+  filters: PathFilter[];
+} {
+  // The base expression ends at the first registered delimiter.
+  let firstDelim = -1;
+  for (let i = 0; i < expr.length; i++) {
+    if (DEF_BY_DELIMITER.has(expr[i])) {
+      firstDelim = i;
+      break;
+    }
+  }
+  if (firstDelim < 0) {
+    return { base: expr, filters: [] };
+  }
+
+  const base = expr.substring(0, firstDelim);
+  const filters: PathFilter[] = [];
+  let i = firstDelim;
+  while (i < expr.length) {
+    const def = DEF_BY_DELIMITER.get(expr[i])!;
+    let end = i + 1;
+    while (end < expr.length && !DEF_BY_DELIMITER.has(expr[end])) {
+      end++;
+    }
+    const value = expr.substring(i + 1, end);
+    if (value.length > 0) {
+      filters.push({ field: def.field, column: def.column, value });
+    }
+    i = end;
+  }
+  return { base, filters };
+}
+
+/**
+ * Build filters from an already-parsed spec object (e.g. a server-provided
+ * History API PathSpec) by reading each registered field off the object. Used
+ * by the v2 provider, where the server — not this plugin — parses the request.
+ */
+export function filtersFromFields(spec: Record<string, unknown>): PathFilter[] {
+  const filters: PathFilter[] = [];
+  for (const def of PATH_FILTER_DEFS) {
+    const value = spec[def.field];
+    if (typeof value === 'string' && value.length > 0) {
+      filters.push({ field: def.field, column: def.column, value });
+    }
+  }
+  return filters;
+}
+
+/** Distinct stored columns referenced by the given filters. */
+export function filterColumns(filters: PathFilter[]): string[] {
+  return [...new Set(filters.map(f => f.column))];
+}
+
+/**
+ * Build the parquet-side filter fragment to append to a WHERE clause.
+ *
+ * For each filter: if its column exists in `availableColumns`, append
+ * `AND column = 'value'`; otherwise append `AND 1=0` so the parquet side
+ * contributes nothing — legacy/imported files without the column cannot match,
+ * and the always-tagged SQLite buffer answers through its own filtered subquery.
+ */
+export function buildParquetFilterClause(
+  filters: PathFilter[],
+  availableColumns: Set<string>
+): string {
+  return filters
+    .map(f =>
+      availableColumns.has(f.column)
+        ? ` AND ${f.column} = '${escapeSqlString(f.value)}'`
+        : ' AND 1=0'
+    )
+    .join('');
+}
+
+/**
+ * Build the buffer-side filter fragment. The buffer schema always carries the
+ * registered filter columns, so no existence check is needed.
+ */
+export function buildBufferFilterClause(filters?: PathFilter[]): string {
+  if (!filters || filters.length === 0) {
+    return '';
+  }
+  return filters
+    .map(f => `\n    AND ${f.column} = '${escapeSqlString(f.value)}'`)
+    .join('');
+}
+
+/** Response-echo properties for a set of filters, e.g. { sourceRef: '...' }. */
+export function filterEcho(filters: PathFilter[]): Record<string, string> {
+  return Object.fromEntries(filters.map(f => [f.field, f.value]));
+}
+
+/** Minimal view of a DuckDB connection needed to probe a parquet schema. */
+export interface SchemaProbeConnection {
+  runAndReadAll: (sql: string) => Promise<{ getRowObjects: () => unknown[] }>;
+}
+
+/**
+ * Returns true if any of the given parquet globs exposes `column`. Null/empty
+ * paths, globs that match no files, and probe errors are treated as "absent",
+ * so a query that reads from S3 isn't penalised by a local glob that matches no
+ * files (and vice versa).
+ */
+export async function parquetHasColumn(
+  connection: SchemaProbeConnection,
+  filePaths: Array<string | null | undefined>,
+  column: string
+): Promise<boolean> {
+  for (const filePath of filePaths) {
+    if (!filePath) {
+      continue;
+    }
+    try {
+      const result = await connection.runAndReadAll(
+        `SELECT 1 FROM parquet_schema('${filePath}') WHERE name = '${column}' LIMIT 1`
+      );
+      if (result.getRowObjects().length > 0) {
+        return true;
+      }
+    } catch {
+      // Path may match no files; treat as absent and try the next.
+    }
+  }
+  return false;
+}
+
+/**
+ * The subset of the filters' columns that actually exist in the given parquet
+ * globs. Pass the result to buildParquetFilterClause so absent columns become
+ * `AND 1=0` rather than a "column not found" error.
+ */
+export async function availableFilterColumns(
+  connection: SchemaProbeConnection,
+  filePaths: Array<string | null | undefined>,
+  filters: PathFilter[]
+): Promise<Set<string>> {
+  const available = new Set<string>();
+  for (const column of filterColumns(filters)) {
+    if (await parquetHasColumn(connection, filePaths, column)) {
+      available.add(column);
+    }
+  }
+  return available;
+}

--- a/src/utils/sql-escape.ts
+++ b/src/utils/sql-escape.ts
@@ -1,0 +1,19 @@
+/**
+ * Helpers for safely embedding string literals in the SQL we build by
+ * interpolation for DuckDB. The query builders in this plugin assemble SQL as
+ * strings rather than using bound parameters, so any externally-supplied value
+ * (context, source reference, timestamps) must be escaped before it is spliced
+ * into a quoted literal.
+ */
+
+/**
+ * Escape a string for inclusion inside a single-quoted SQL literal by doubling
+ * embedded single quotes. This is the standard SQL escaping for string
+ * literals and prevents the value from terminating the literal early.
+ *
+ * Input:  O'Brien        Output: O''Brien
+ * Usage:  `WHERE label = '${escapeSqlString(value)}'`
+ */
+export function escapeSqlString(value: string): string {
+  return value.replace(/'/g, "''");
+}


### PR DESCRIPTION
## Summary

Adds optional source filtering to the History API, implementing the provider/query side of [SignalK/signalk-server#2737](https://github.com/SignalK/signalk-server/pull/2737) (which addresses [SignalK/signalk-server#2706](https://github.com/SignalK/signalk-server/issues/2706)).

Callers append `|<sourceRef>` to a path expression to restrict it to a single SignalK source:

```
navigation.headingMagnetic:average|n2k-on-ve.can0.115
```

This lets applications distinguish historical data from multiple devices publishing the same path, e.g. several heading sensors for compass calibration, or multiple GPS receivers.

## What changed

- **Parsing (v1 HTTP routes, `HistoryAPI.ts`):** a path expression is split into its base (`path:aggregate:smoothing`) and any inline filters before the existing `:` parsing. The `paths` sanitiser preserves the filter delimiters and `-` (common in source references, and previously stripped — which would have corrupted refs like `n2k-on-ve.can0.115`).
- **Query filtering:** the filter targets the raw-tier `source_label` column (where the delta's `$source` is stored) across the parquet tier, the SQLite buffer, and the buffer-only fallback. A filter forces raw reads because aggregated tiers (5s/60s/1h) blend every source into each bucket and drop the column.
- **Robustness:** the parquet schema is probed (local and S3) for the filter column first; legacy or externally imported files without it are excluded (`AND 1=0`) rather than throwing, leaving the always-tagged buffer to answer the query.
- **Distinct series:** intermediate results are keyed by the full path spec (path, aggregate, smoothing, filters), so the same path requested with different sources or aggregates stays in separate columns instead of overwriting each other.
- **v2 provider (`history-provider.ts`):** the registered History API provider derives filters from the server-parsed PathSpec and applies the same filtering.
- **Response:** each `values` entry echoes the filter (e.g. `sourceRef`) it was restricted to.
- README documents the `|sourceRef` syntax.

## Behaviour

| Expression | Result |
|---|---|
| `navigation.speedOverGround` | average, all sources |
| `navigation.speedOverGround:max` | max, all sources |
| `navigation.speedOverGround\|n2k-on-ve.can0.115` | average, one source |
| `navigation.speedOverGround:max\|n2k-on-ve.can0.115` | max, one source |

## Extensibility

The filter mechanism is registry-driven (`utils/path-filters.ts`). Adding another inline filter (e.g. by `source_type`) is a single entry:

```ts
export const PATH_FILTER_DEFS: readonly PathFilterDef[] = [
  { delimiter: '|', field: 'sourceRef', column: 'source_label' },
];
```

Parsing, raw-tier forcing, parquet/buffer SQL, schema probing, result keying, the response echo, and the path sanitiser's allowed delimiters all derive from the registry. `PathSpec` carries `filters: PathFilter[]`; the v1 routes parse them and the v2 provider derives them from the server-parsed spec via the same registry. The only requirement for a new filter is that its column is written to raw parquet and the SQLite buffer (the `source_*` columns already are).

## Testing

- `npm run build` passes (`tsc`, no errors).
- Verified parsing, SQL fragment building, quote-escaping, and provider field mapping against the compiled filter module (16 cases), including that `-` and `.` in source references survive sanitisation and that distinct sources/aggregates stay in separate columns.
- Source references are SQL-escaped (single-quote doubling) on both the parquet and buffer sides.

The repository has no automated test harness, so changes were validated via the compiler and standalone checks.
