### PR TITLE
Support self-hosted S3 like Garage, or S3 compatible online services

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -934,7 +934,7 @@
         "long": "^5.3.1",
         "node-int64": "^0.4.0",
         "snappyjs": "^0.7.0",
-        "thrift": "0.23.0",
+        "thrift": "0.21.0",
         "varint": "^6.0.0",
         "xxhash-wasm": "^1.1.0"
       },
@@ -7079,19 +7079,33 @@
       "license": "MIT"
     },
     "node_modules/thrift": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.21.0.tgz",
-      "integrity": "sha512-AW8rwHYjeqXisS8B1iwko2gkNMFwSRJ+bO/W0xTGqRspTD3lGHwZx438+pHdOJ3GwpRAnK7TKbjqPOrHAa7ZwQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.23.0.tgz",
+      "integrity": "sha512-j7F1ls8JogClU88Ta/pwD/OzYuiFeD6Z5GoWw7ip+jcDhcNYFKgfXYEsyLXYpiNfJO94fbLnITGxyfZ19YzA6Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "browser-or-node": "^1.2.1",
         "isomorphic-ws": "^4.0.1",
         "node-int64": "^0.4.0",
         "q": "^1.5.0",
+        "uuid": "^13.0.0",
         "ws": "^5.2.3"
       },
       "engines": {
         "node": ">= 10.18.0"
+      }
+    },
+    "node_modules/thrift/node_modules/uuid": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/thrift/node_modules/ws": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-parquet",
-  "version": "0.7.40-beta.1",
+  "version": "0.7.41-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-parquet",
-      "version": "0.7.40-beta.1",
+      "version": "0.7.41-beta.1",
       "cpu": [
         "x64",
         "arm64",

--- a/package-lock.json
+++ b/package-lock.json
@@ -934,7 +934,7 @@
         "long": "^5.3.1",
         "node-int64": "^0.4.0",
         "snappyjs": "^0.7.0",
-        "thrift": "0.21.0",
+        "thrift": "0.23.0",
         "varint": "^6.0.0",
         "xxhash-wasm": "^1.1.0"
       },

--- a/src/data-handler.ts
+++ b/src/data-handler.ts
@@ -108,10 +108,21 @@ export function createCloudClient(config: PluginConfig, app: ServerAPI): any {
     // S3 provider
     const s3Config: {
       region: string;
+      endpoint?: string;
+      forcePathStyle?: boolean;
       credentials?: { accessKeyId: string; secretAccessKey: string };
     } = {
       region: cloud.region || 'us-east-1',
     };
+
+    if (cloud.endpoint) {
+      s3Config.endpoint = cloud.endpoint;
+    }
+
+    s3Config.forcePathStyle =
+      cloud.forcePathStyle !== undefined
+        ? cloud.forcePathStyle
+        : !!cloud.endpoint;
 
     if (cloud.accessKeyId && cloud.secretAccessKey) {
       s3Config.credentials = {

--- a/src/data-handler.ts
+++ b/src/data-handler.ts
@@ -28,6 +28,7 @@ import {
   NormalizedDelta,
 } from './types';
 import { extractCommandName } from './commands';
+import { resolveCustomS3Endpoint } from './utils/cloud-endpoint';
 import {
   Context,
   Delta,
@@ -116,13 +117,16 @@ export function createCloudClient(config: PluginConfig, app: ServerAPI): any {
     };
 
     if (cloud.endpoint) {
-      s3Config.endpoint = cloud.endpoint;
+      const custom = resolveCustomS3Endpoint(
+        cloud.endpoint,
+        cloud.forcePathStyle
+      );
+      s3Config.endpoint = custom.url;
+      s3Config.forcePathStyle = custom.forcePathStyle;
+    } else {
+      s3Config.forcePathStyle =
+        cloud.forcePathStyle !== undefined ? cloud.forcePathStyle : false;
     }
-
-    s3Config.forcePathStyle =
-      cloud.forcePathStyle !== undefined
-        ? cloud.forcePathStyle
-        : !!cloud.endpoint;
 
     if (cloud.accessKeyId && cloud.secretAccessKey) {
       s3Config.credentials = {
@@ -904,16 +908,16 @@ async function putToCloud(
 ): Promise<boolean> {
   if (!target.client || !PutObjectCommand) return false;
 
-  try {
-    const relativePath = path.relative(config.outputDirectory, filePath);
-    let cloudKey = relativePath;
-    if (target.keyPrefix) {
-      const prefix = target.keyPrefix.endsWith('/')
-        ? target.keyPrefix
-        : `${target.keyPrefix}/`;
-      cloudKey = `${prefix}${relativePath}`;
-    }
+  const relativePath = path.relative(config.outputDirectory, filePath);
+  let cloudKey = relativePath;
+  if (target.keyPrefix) {
+    const prefix = target.keyPrefix.endsWith('/')
+      ? target.keyPrefix
+      : `${target.keyPrefix}/`;
+    cloudKey = `${prefix}${relativePath}`;
+  }
 
+  try {
     const fileContent = await fs.readFile(filePath);
     await target.client.send(
       new PutObjectCommand({
@@ -928,7 +932,10 @@ async function putToCloud(
       await fs.unlink(filePath);
     }
     return true;
-  } catch {
+  } catch (err) {
+    appInstance?.error(
+      `[CloudSync] Upload failed for ${cloudKey}: ${(err as Error).message}`
+    );
     return false;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -348,38 +348,44 @@ export default function (app: ServerAPI): SignalKPlugin {
       state.currentConfig.cloudUpload.accessKeyId &&
       state.currentConfig.cloudUpload.secretAccessKey
     ) {
-      try {
-        const isR2 = state.currentConfig.cloudUpload.provider === 'r2';
-        let endpoint: string | undefined;
-        let useSSL: boolean | undefined;
-        let urlStyle: 'path' | 'vhost' | undefined;
-        if (isR2) {
-          endpoint = `${state.currentConfig.cloudUpload.accountId}.r2.cloudflarestorage.com`;
-          urlStyle = 'path';
-        } else if (state.currentConfig.cloudUpload.endpoint) {
-          // Self-hosted S3-compatible endpoint (e.g. Garage, MinIO)
-          const parsed = new URL(state.currentConfig.cloudUpload.endpoint);
-          endpoint = parsed.host;
-          useSSL = parsed.protocol === 'https:';
-          const forcePathStyle =
-            state.currentConfig.cloudUpload.forcePathStyle !== undefined
-              ? state.currentConfig.cloudUpload.forcePathStyle
-              : true;
-          urlStyle = forcePathStyle ? 'path' : 'vhost';
+      const isR2 = state.currentConfig.cloudUpload.provider === 'r2';
+      if (isR2 && !state.currentConfig.cloudUpload.accountId) {
+        app.error(
+          'R2 cloud upload enabled but no account ID configured; skipping DuckDB S3 credential setup'
+        );
+      } else {
+        try {
+          let endpoint: string | undefined;
+          let useSSL: boolean | undefined;
+          let urlStyle: 'path' | 'vhost' | undefined;
+          if (isR2) {
+            endpoint = `${state.currentConfig.cloudUpload.accountId}.r2.cloudflarestorage.com`;
+            urlStyle = 'path';
+          } else if (state.currentConfig.cloudUpload.endpoint) {
+            // Self-hosted S3-compatible endpoint (e.g. Garage, MinIO)
+            const parsed = new URL(state.currentConfig.cloudUpload.endpoint);
+            endpoint = parsed.host;
+            useSSL = parsed.protocol === 'https:';
+            const forcePathStyle =
+              state.currentConfig.cloudUpload.forcePathStyle !== undefined
+                ? state.currentConfig.cloudUpload.forcePathStyle
+                : true;
+            urlStyle = forcePathStyle ? 'path' : 'vhost';
+          }
+          await DuckDBPool.initializeS3({
+            accessKeyId: state.currentConfig.cloudUpload.accessKeyId,
+            secretAccessKey: state.currentConfig.cloudUpload.secretAccessKey,
+            region: isR2
+              ? 'auto'
+              : state.currentConfig.cloudUpload.region || 'us-east-1',
+            endpoint,
+            useSSL,
+            urlStyle,
+          });
+          app.debug('DuckDB S3 credentials initialized for federated queries');
+        } catch (error) {
+          app.error(`Failed to initialize DuckDB S3 credentials: ${error}`);
         }
-        await DuckDBPool.initializeS3({
-          accessKeyId: state.currentConfig.cloudUpload.accessKeyId,
-          secretAccessKey: state.currentConfig.cloudUpload.secretAccessKey,
-          region: isR2
-            ? 'auto'
-            : state.currentConfig.cloudUpload.region || 'us-east-1',
-          endpoint,
-          useSSL,
-          urlStyle,
-        });
-        app.debug('DuckDB S3 credentials initialized for federated queries');
-      } catch (error) {
-        app.error(`Failed to initialize DuckDB S3 credentials: ${error}`);
       }
     }
 
@@ -1082,8 +1088,7 @@ export default function (app: ServerAPI): SignalKPlugin {
                     type: 'boolean',
                     title: 'Use Path-Style Addressing',
                     description:
-                      'Use path-style bucket addressing (https://endpoint/bucket) instead of virtual-hosted-style (https://bucket.endpoint). Often required by self-hosted S3-compatible services like Garage or MinIO.',
-                    default: false,
+                      'Use path-style bucket addressing (https://endpoint/bucket) instead of virtual-hosted-style (https://bucket.endpoint). Often required by self-hosted S3-compatible services like Garage or MinIO. If left unset, defaults to enabled when a custom endpoint is configured.',
                   },
                 },
                 description:

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import {
 import { ServerAPI } from '@signalk/server-api';
 import { DuckDBPool } from './utils/duckdb-pool';
 import { LRUCache } from './utils/lru-cache';
+import { resolveCustomS3Endpoint } from './utils/cloud-endpoint';
 import {
   registerHistoryApiProvider,
   unregisterHistoryApiProvider,
@@ -363,14 +364,13 @@ export default function (app: ServerAPI): SignalKPlugin {
             urlStyle = 'path';
           } else if (state.currentConfig.cloudUpload.endpoint) {
             // Self-hosted S3-compatible endpoint (e.g. Garage, MinIO)
-            const parsed = new URL(state.currentConfig.cloudUpload.endpoint);
-            endpoint = parsed.host;
-            useSSL = parsed.protocol === 'https:';
-            const forcePathStyle =
-              state.currentConfig.cloudUpload.forcePathStyle !== undefined
-                ? state.currentConfig.cloudUpload.forcePathStyle
-                : true;
-            urlStyle = forcePathStyle ? 'path' : 'vhost';
+            const resolved = resolveCustomS3Endpoint(
+              state.currentConfig.cloudUpload.endpoint,
+              state.currentConfig.cloudUpload.forcePathStyle
+            );
+            endpoint = resolved.host;
+            useSSL = resolved.useSSL;
+            urlStyle = resolved.forcePathStyle ? 'path' : 'vhost';
           }
           await DuckDBPool.initializeS3({
             accessKeyId: state.currentConfig.cloudUpload.accessKeyId,
@@ -384,7 +384,9 @@ export default function (app: ServerAPI): SignalKPlugin {
           });
           app.debug('DuckDB S3 credentials initialized for federated queries');
         } catch (error) {
-          app.error(`Failed to initialize DuckDB S3 credentials: ${error}`);
+          app.error(
+            `Failed to initialize DuckDB S3 credentials: ${(error as Error).message}`
+          );
         }
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -350,15 +350,32 @@ export default function (app: ServerAPI): SignalKPlugin {
     ) {
       try {
         const isR2 = state.currentConfig.cloudUpload.provider === 'r2';
+        let endpoint: string | undefined;
+        let useSSL: boolean | undefined;
+        let urlStyle: 'path' | 'vhost' | undefined;
+        if (isR2) {
+          endpoint = `${state.currentConfig.cloudUpload.accountId}.r2.cloudflarestorage.com`;
+          urlStyle = 'path';
+        } else if (state.currentConfig.cloudUpload.endpoint) {
+          // Self-hosted S3-compatible endpoint (e.g. Garage, MinIO)
+          const parsed = new URL(state.currentConfig.cloudUpload.endpoint);
+          endpoint = parsed.host;
+          useSSL = parsed.protocol === 'https:';
+          const forcePathStyle =
+            state.currentConfig.cloudUpload.forcePathStyle !== undefined
+              ? state.currentConfig.cloudUpload.forcePathStyle
+              : true;
+          urlStyle = forcePathStyle ? 'path' : 'vhost';
+        }
         await DuckDBPool.initializeS3({
           accessKeyId: state.currentConfig.cloudUpload.accessKeyId,
           secretAccessKey: state.currentConfig.cloudUpload.secretAccessKey,
           region: isR2
             ? 'auto'
             : state.currentConfig.cloudUpload.region || 'us-east-1',
-          endpoint: isR2
-            ? `${state.currentConfig.cloudUpload.accountId}.r2.cloudflarestorage.com`
-            : undefined,
+          endpoint,
+          useSSL,
+          urlStyle,
         });
         app.debug('DuckDB S3 credentials initialized for federated queries');
       } catch (error) {
@@ -1050,12 +1067,27 @@ export default function (app: ServerAPI): SignalKPlugin {
                   region: {
                     type: 'string',
                     title: 'AWS Region',
-                    description: 'AWS region where the S3 bucket is located',
+                    description:
+                      'AWS region where the S3 bucket is located.',
                     default: 'us-east-1',
+                  },
+                  endpoint: {
+                    type: 'string',
+                    title: 'Custom Endpoint URL (optional)',
+                    description:
+                      'Override the S3 endpoint for self-hosted S3-compatible storage (e.g. Garage, MinIO). Include the protocol and port, e.g. "https://garage.example.com:3900". Leave blank for AWS S3.',
+                    default: '',
+                  },
+                  forcePathStyle: {
+                    type: 'boolean',
+                    title: 'Use Path-Style Addressing',
+                    description:
+                      'Use path-style bucket addressing (https://endpoint/bucket) instead of virtual-hosted-style (https://bucket.endpoint). Often required by self-hosted S3-compatible services like Garage or MinIO.',
+                    default: false,
                   },
                 },
                 description:
-                  'NOTE: Querying S3 buckets incurs AWS data transfer costs that can rise quickly with large or frequent queries. Typically, R2 has no such fees.',
+                  'NOTE: Querying S3 buckets incurs AWS data transfer costs that can rise quickly with large or frequent queries. Typically, R2 has no such fees. Self-hosted services like Garage typically have no such fees either.',
               },
               {
                 properties: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -364,13 +364,13 @@ export default function (app: ServerAPI): SignalKPlugin {
             urlStyle = 'path';
           } else if (state.currentConfig.cloudUpload.endpoint) {
             // Self-hosted S3-compatible endpoint (e.g. Garage, MinIO)
-            const resolved = resolveCustomS3Endpoint(
+            const custom = resolveCustomS3Endpoint(
               state.currentConfig.cloudUpload.endpoint,
               state.currentConfig.cloudUpload.forcePathStyle
             );
-            endpoint = resolved.host;
-            useSSL = resolved.useSSL;
-            urlStyle = resolved.forcePathStyle ? 'path' : 'vhost';
+            endpoint = custom.host;
+            useSSL = custom.useSSL;
+            urlStyle = custom.forcePathStyle ? 'path' : 'vhost';
           }
           await DuckDBPool.initializeS3({
             accessKeyId: state.currentConfig.cloudUpload.accessKeyId,

--- a/src/types.ts
+++ b/src/types.ts
@@ -275,7 +275,9 @@ export interface WebAppPathConfig {
 export interface CloudUploadConfig {
   provider: 'none' | 's3' | 'r2';
   bucket?: string;
-  region?: string; // S3 only
+  region?: string; // S3 only (e.g. 'us-east-1', or 'garage' for Garage)
+  endpoint?: string; // S3 only - custom endpoint URL for self-hosted S3-compatible services (Garage, MinIO, etc.)
+  forcePathStyle?: boolean; // S3 only - use path-style addressing instead of virtual-hosted-style (often required by self-hosted S3-compatible services)
   accountId?: string; // R2 only (Cloudflare account ID)
   keyPrefix?: string;
   accessKeyId?: string;

--- a/src/utils/cloud-endpoint.ts
+++ b/src/utils/cloud-endpoint.ts
@@ -1,0 +1,40 @@
+// Resolves a self-hosted S3-compatible endpoint (e.g. Garage, MinIO) into the
+// pieces both the AWS SDK client and DuckDB's S3 extension need.
+export interface ResolvedS3Endpoint {
+  url: string; // original endpoint, validated (includes scheme)
+  host: string; // host[:port], no scheme - what DuckDB's ENDPOINT expects
+  useSSL: boolean;
+  forcePathStyle: boolean;
+}
+
+export function resolveCustomS3Endpoint(
+  endpoint: string,
+  forcePathStyleConfig: boolean | undefined
+): ResolvedS3Endpoint {
+  let parsed: URL;
+  try {
+    parsed = new URL(endpoint);
+  } catch {
+    throw new Error(
+      `cloudUpload.endpoint must be a full URL including scheme (e.g. "https://${endpoint}"), got: "${endpoint}"`
+    );
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(
+      `cloudUpload.endpoint must use http:// or https://, got: "${endpoint}"`
+    );
+  }
+
+  if (!parsed.host) {
+    throw new Error(`cloudUpload.endpoint is missing a host: "${endpoint}"`);
+  }
+
+  return {
+    url: endpoint,
+    host: parsed.host,
+    useSSL: parsed.protocol === 'https:',
+    forcePathStyle:
+      forcePathStyleConfig !== undefined ? forcePathStyleConfig : true,
+  };
+}

--- a/src/utils/cloud-endpoint.ts
+++ b/src/utils/cloud-endpoint.ts
@@ -30,6 +30,16 @@ export function resolveCustomS3Endpoint(
     throw new Error(`cloudUpload.endpoint is missing a host: "${endpoint}"`);
   }
 
+  if (
+    (parsed.pathname && parsed.pathname !== '/') ||
+    parsed.search ||
+    parsed.hash
+  ) {
+    throw new Error(
+      `cloudUpload.endpoint must be an origin only (scheme + host[:port]), with no path, query, or fragment: "${endpoint}"`
+    );
+  }
+
   return {
     url: endpoint,
     host: parsed.host,

--- a/src/utils/duckdb-pool.ts
+++ b/src/utils/duckdb-pool.ts
@@ -26,7 +26,9 @@ export interface S3Config {
   accessKeyId: string;
   secretAccessKey: string;
   region: string;
-  endpoint?: string; // R2: '{accountId}.r2.cloudflarestorage.com'
+  endpoint?: string; // R2: '{accountId}.r2.cloudflarestorage.com', or host[:port] for self-hosted S3 (Garage, MinIO, etc.)
+  useSSL?: boolean; // Set to false for self-hosted endpoints served over plain HTTP
+  urlStyle?: 'path' | 'vhost'; // R2 and most self-hosted S3-compatible services require 'path'
 }
 
 export class DuckDBPool {
@@ -174,10 +176,17 @@ export class DuckDBPool {
       await connection.runAndReadAll('INSTALL httpfs;');
       await connection.runAndReadAll('LOAD httpfs;');
 
-      // Create S3 secret — R2 needs ENDPOINT and URL_STYLE 'path'
-      const endpointClause = config.endpoint
-        ? `,\n          ENDPOINT '${config.endpoint.replace(/'/g, "''")}',\n          URL_STYLE 'path'`
+      // Create S3 secret — R2 and self-hosted S3-compatible services (Garage, MinIO)
+      // typically need ENDPOINT and URL_STYLE 'path'
+      let endpointClause = config.endpoint
+        ? `,\n          ENDPOINT '${config.endpoint.replace(/'/g, "''")}'`
         : '';
+      if (config.urlStyle) {
+        endpointClause += `,\n          URL_STYLE '${config.urlStyle}'`;
+      }
+      if (config.endpoint && config.useSSL !== undefined) {
+        endpointClause += `,\n          USE_SSL ${config.useSSL ? 'true' : 'false'}`;
+      }
       const secretSql = `
         CREATE OR REPLACE SECRET s3_credentials (
           TYPE S3,


### PR DESCRIPTION
Added two new config options:

* API Endpoint URL
* Force path style access

These allow S3 sync to work with non-AWS S3 compatible service (tested successfully with my self-hosted Garage buckets, wireguard networked back to the boat )

These changes apply to the sync of the parquet files, and the DuckDb access

https://github.com/motamman/signalk-parquet/issues/66