### PR TITLE
chore: add Dependabot config for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  # npm: weekly bumps, groups minor+patch into one PR, majors individual
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+
+  # GitHub Actions: weekly, one grouped PR for everything
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        update-types:
+          - minor
+          - patch
+          - major
+    labels:
+      - dependencies


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to enable automated dependency updates.

- **npm** (`/`): weekly checks. Minor and patch bumps are grouped into a single PR; majors are opened individually. Limit of 10 open PRs.
- **GitHub Actions** (`/`): weekly checks. All update types (minor, patch, major) grouped into one PR. Limit of 5 open PRs.

Both ecosystems apply the `dependencies` label. Dependabot provisions this default label automatically if it is not already present.