### PR TITLE
fix: remove whole-store scans that stall startup on large stores

### DIFF
--- a/src/parquet-writer.ts
+++ b/src/parquet-writer.ts
@@ -995,10 +995,18 @@ export async function quarantineEmptyParquetFiles(
 
   await walk(baseDirectory);
 
-  // Record this sweep's start as the next run's cutoff. Using the start time
-  // (not end) means files written while the sweep ran are re-checked next time.
+  // Record the next run's cutoff: the sweep's start (not end, so files written
+  // while it ran are re-checked), minus a slack margin so a coarse-resolution
+  // filesystem (1s mtime) or a same-second write can't round a just-created
+  // directory below the watermark and skip it. The overlap only re-inspects
+  // directories touched in the ~2s around this sweep.
+  const WATERMARK_SLACK_MS = 2000;
   try {
-    await fs.writeFile(stateFile, String(sweepStart), 'utf8');
+    await fs.writeFile(
+      stateFile,
+      String(sweepStart - WATERMARK_SLACK_MS),
+      'utf8'
+    );
   } catch (err) {
     app.error(
       `Failed to persist empty-sweep watermark ${stateFile}: ${(err as Error).message}`

--- a/src/parquet-writer.ts
+++ b/src/parquet-writer.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { glob } from 'glob';
 import { DataRecord, ParquetWriterOptions, FileFormat } from './types';
 import { ServerAPI } from '@signalk/server-api';
 import { SchemaService } from './schema-service';
@@ -899,6 +898,13 @@ export class ParquetWriter {
  * on plugin start. Files are moved to a sibling `quarantine/` dir, matching
  * the in-flight quarantine layout; the History API already excludes those
  * paths from queries.
+ *
+ * The sweep is incremental: a stub is a newly *created* file, which bumps its
+ * parent directory's mtime, so directories unchanged since the last sweep are
+ * skipped. The last-sweep time is persisted in `<baseDirectory>/.last-empty-
+ * sweep`; the first run (no watermark) scans everything once to catch any
+ * pre-existing stub, then later runs cost O(directories changed since the
+ * previous start) and still catch a stub of any age after long downtime.
  */
 export async function quarantineEmptyParquetFiles(
   app: ServerAPI,
@@ -908,39 +914,95 @@ export async function quarantineEmptyParquetFiles(
     return { quarantined: 0, failed: 0 };
   }
 
-  const candidates = await glob(path.join(baseDirectory, '**', '*.parquet'), {
-    ignore: [
-      path.join(baseDirectory, '**', 'quarantine', '**'),
-      path.join(baseDirectory, '**', 'failed', '**'),
-      path.join(baseDirectory, '**', 'repaired', '**'),
-      path.join(baseDirectory, '**', '.compaction-trash-*', '**'),
-    ],
-  });
+  // Persisted last-sweep timestamp. Missing/unparseable (first run after this
+  // change) leaves the watermark at 0, so everything is scanned once to catch
+  // pre-existing stubs; subsequent runs only inspect directories changed since.
+  const stateFile = path.join(baseDirectory, '.last-empty-sweep');
+  let watermark = 0;
+  try {
+    const parsed = Number((await fs.readFile(stateFile, 'utf8')).trim());
+    if (Number.isFinite(parsed)) watermark = parsed;
+  } catch {
+    // No prior sweep recorded — proceed with watermark = 0 (full scan once).
+  }
+
+  const sweepStart = Date.now();
+  const ignoredDir = (name: string): boolean =>
+    name === 'quarantine' ||
+    name === 'failed' ||
+    name === 'repaired' ||
+    name.startsWith('.compaction-trash-');
 
   let quarantined = 0;
   let failed = 0;
 
-  for (const file of candidates) {
+  const walk = async (dir: string): Promise<void> => {
+    let entries: import('fs').Dirent[];
     try {
-      const stats = await fs.stat(file);
-      if (stats.size >= 100) continue;
-
-      const quarantineDir = path.join(path.dirname(file), 'quarantine');
-      await fs.ensureDir(quarantineDir);
-      const quarantinePath = path.join(quarantineDir, path.basename(file));
-      await fs.move(file, quarantinePath, { overwrite: true });
-
-      const logLine = `${new Date().toISOString()} | startup-sweep | ${stats.size} bytes | Undersized parquet (likely crash between openFile and close) | ${quarantinePath}\n`;
-      await fs.appendFile(path.join(quarantineDir, 'quarantine.log'), logLine);
-
-      quarantined++;
-      app.debug(`Quarantined undersized parquet (${stats.size}B): ${file}`);
-    } catch (err) {
-      failed++;
-      app.error(
-        `Failed to quarantine undersized parquet ${file}: ${(err as Error).message}`
-      );
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return; // unreadable directory — skip
     }
+
+    // A new stub bumps the mtime of the directory it was created in, so a
+    // directory unchanged since the last sweep has no new files to check.
+    // Subdirectories are always descended: an ancestor's mtime does NOT change
+    // when a file is added deep in the tree.
+    let inspectFiles = true;
+    if (watermark > 0) {
+      try {
+        inspectFiles = (await fs.stat(dir)).mtimeMs > watermark;
+      } catch {
+        inspectFiles = true;
+      }
+    }
+
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (!ignoredDir(entry.name)) {
+          await walk(path.join(dir, entry.name));
+        }
+        continue;
+      }
+      if (!inspectFiles || !entry.name.endsWith('.parquet')) continue;
+
+      const file = path.join(dir, entry.name);
+      try {
+        const stats = await fs.stat(file);
+        if (stats.size >= 100) continue;
+
+        const quarantineDir = path.join(dir, 'quarantine');
+        await fs.ensureDir(quarantineDir);
+        const quarantinePath = path.join(quarantineDir, entry.name);
+        await fs.move(file, quarantinePath, { overwrite: true });
+
+        const logLine = `${new Date().toISOString()} | startup-sweep | ${stats.size} bytes | Undersized parquet (likely crash between openFile and close) | ${quarantinePath}\n`;
+        await fs.appendFile(
+          path.join(quarantineDir, 'quarantine.log'),
+          logLine
+        );
+
+        quarantined++;
+        app.debug(`Quarantined undersized parquet (${stats.size}B): ${file}`);
+      } catch (err) {
+        failed++;
+        app.error(
+          `Failed to quarantine undersized parquet ${file}: ${(err as Error).message}`
+        );
+      }
+    }
+  };
+
+  await walk(baseDirectory);
+
+  // Record this sweep's start as the next run's cutoff. Using the start time
+  // (not end) means files written while the sweep ran are re-checked next time.
+  try {
+    await fs.writeFile(stateFile, String(sweepStart), 'utf8');
+  } catch (err) {
+    app.error(
+      `Failed to persist empty-sweep watermark ${stateFile}: ${(err as Error).message}`
+    );
   }
 
   if (quarantined > 0) {

--- a/src/utils/path-discovery.ts
+++ b/src/utils/path-discovery.ts
@@ -13,7 +13,14 @@ import { DuckDBPool } from './duckdb-pool';
 export function getAvailablePaths(
   dataDir: string,
   app: ServerAPI,
-  context?: string
+  context?: string,
+  // When false, a path is included as soon as one parquet file is found rather
+  // than counting every file. countParquetFilesRecursive descends every
+  // year=/day= partition and stats every file — on a large store that is
+  // millions of synchronous calls that block the event loop. Callers that
+  // display the count (UI, analyzer) keep the default; the History API path
+  // list, which discards the count, passes false. Both return the same paths.
+  countFiles: boolean = true
 ): PathInfo[] {
   const paths: PathInfo[] = [];
   const hiveBuilder = new HivePathBuilder();
@@ -60,8 +67,14 @@ export function getAvailablePaths(
         const sanitizedPath = pathDir.replace('path=', '');
         const unsanitizedPath = hiveBuilder.unsanitizePath(sanitizedPath);
 
-        // Count parquet files across all year=/day=/ subdirs
-        const fileCount = countParquetFilesRecursive(pathPath);
+        // Count parquet files across all year=/day=/ subdirs, or just confirm
+        // at least one exists when the count is not needed (far cheaper, same
+        // inclusion result).
+        const fileCount = countFiles
+          ? countParquetFilesRecursive(pathPath)
+          : hasParquetFilesRecursiveSync(pathPath)
+            ? 1
+            : 0;
 
         if (fileCount > 0) {
           paths.push({
@@ -106,6 +119,32 @@ function countParquetFilesRecursive(dir: string): number {
 }
 
 /**
+ * Return true as soon as a single parquet file is found anywhere under `dir`.
+ * Mirrors countParquetFilesRecursive's traversal exactly (recurses every
+ * subdirectory, no special-dir skipping) so it includes the same paths, but
+ * short-circuits on the first hit and uses Dirent types instead of a statSync
+ * per entry — turning a full census into a handful of readdirs.
+ */
+function hasParquetFilesRecursiveSync(dir: string): boolean {
+  try {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (hasParquetFilesRecursiveSync(path.join(dir, entry.name))) {
+          return true;
+        }
+      } else if (entry.name.endsWith('.parquet')) {
+        return true;
+      }
+    }
+  } catch (error) {
+    // Error reading directory - skip
+  }
+  return false;
+}
+
+/**
  * Get available SignalK paths as simple string array
  * Useful for SignalK history API compliance
  */
@@ -114,7 +153,9 @@ export function getAvailablePathsArray(
   app: ServerAPI,
   context?: string
 ): string[] {
-  const pathInfos = getAvailablePaths(dataDir, app, context);
+  // Path names only — skip the per-file count so this stays cheap even on a
+  // store with millions of parquet files (this is the History API hot path).
+  const pathInfos = getAvailablePaths(dataDir, app, context, false);
   return pathInfos.map(pathInfo => pathInfo.path);
 }
 

--- a/src/utils/path-discovery.ts
+++ b/src/utils/path-discovery.ts
@@ -122,19 +122,38 @@ function countParquetFilesRecursive(dir: string): number {
  * Return true as soon as a single parquet file is found anywhere under `dir`.
  * Mirrors countParquetFilesRecursive's traversal exactly (recurses every
  * subdirectory, no special-dir skipping) so it includes the same paths, but
- * short-circuits on the first hit and uses Dirent types instead of a statSync
- * per entry — turning a full census into a handful of readdirs.
+ * short-circuits on the first hit and uses Dirent types (falling back to stat
+ * only for symlinks/unknown entries) instead of a statSync per entry — turning
+ * a full census into a handful of readdirs.
  */
 function hasParquetFilesRecursiveSync(dir: string): boolean {
   try {
     const entries = fs.readdirSync(dir, { withFileTypes: true });
 
     for (const entry of entries) {
-      if (entry.isDirectory()) {
+      let isDir = entry.isDirectory();
+      let isParquet =
+        !isDir && entry.isFile() && entry.name.endsWith('.parquet');
+
+      // Dirent types are unreliable for symlinks (reported as the link, not its
+      // target) and on filesystems that return unknown types. For those rare
+      // entries fall back to stat (which follows the link) so traversal matches
+      // countParquetFilesRecursive. The data tree has no symlinks in practice,
+      // so the fast Dirent path covers essentially everything.
+      if (!isDir && !isParquet && !entry.isFile()) {
+        try {
+          isDir = fs.statSync(path.join(dir, entry.name)).isDirectory();
+          isParquet = !isDir && entry.name.endsWith('.parquet');
+        } catch {
+          // broken symlink / unreadable entry — skip
+        }
+      }
+
+      if (isDir) {
         if (hasParquetFilesRecursiveSync(path.join(dir, entry.name))) {
           return true;
         }
-      } else if (entry.name.endsWith('.parquet')) {
+      } else if (isParquet) {
         return true;
       }
     }


### PR DESCRIPTION
## Summary

Two unconditional whole-store scans ran on a large install and stalled the
plugin — one freezing `plugin.start`, the other freezing the first History API
path request after a restart. Both are replaced with bounded/short-circuiting
scans. Verified on a real vessel install (~3.3M parquet files / 51 GB).

---

## Fix 1 — Empty-parquet startup sweep (`parquet-writer.ts`)

### Problem

`quarantineEmptyParquetFiles()` runs on every plugin start to move aside 0-byte
parquet stubs left by a hard crash between `ParquetWriter.openFile()` and
`close()`. It did this by globbing the **entire** data directory
(`**/*.parquet`) and `stat`-ing every match.

On a large store this is pathological — every restart froze for **6–20 minutes**:

- `glob` builds a multi-GB in-memory array of ~3.3M path strings, and
- micromatch-evaluates the `ignore:` patterns against every one of those paths
  **on the main thread**.

Result: event loop pegged at 100% CPU, RSS climbing to ~4 GB, HTTP backlog
growing, and `plugin.start` never reaching `DuckDB pool init`. Reproduced
identically on every restart, and it runs in full even when there are no stubs
to find (the normal case).

### Fix

Make the sweep **incremental**, keyed to the last scan rather than re-walking
everything:

- Persist the last-sweep timestamp in `<dataDir>/.last-empty-sweep`.
- Walk directories, but only `stat` the `.parquet` files in a directory whose
  **mtime is newer than the watermark**. A 0-byte stub is a newly *created*
  file, which bumps its parent directory's mtime — so an unchanged directory
  cannot contain a new stub and its files are skipped.
- Subdirectories are always descended (an ancestor's mtime does **not** change
  when a file is added deep in the tree).
- First run (no watermark) scans everything once to catch any pre-existing
  stub, then writes the watermark; every run after is O(directories changed
  since the previous start).

Also drops `glob`/micromatch for a plain async `readdir`/`stat` walk — no
multi-GB path array, no main-thread pattern matching, so even the one-time
first scan is non-blocking.

**Stays correct:** the cutoff is the last scan, not "now", so a stub left months
ago is still found after long downtime. Otherwise unchanged — same `<100 B`
threshold, same sibling `quarantine/` layout + `quarantine.log`, same
`quarantine`/`failed`/`repaired`/`.compaction-trash-*` exclusions. (Compaction
already writes via temp-file + atomic rename, so final-path stubs only come from
the direct writer path this sweep targets.)

---

## Fix 2 — History API path enumeration (`path-discovery.ts`)

### Problem

The History API path list (`getPaths` / the legacy `/signalk/v1/history/paths`
branch) calls `getAvailablePathsArray`, which returns only path **names** but
got them via `getAvailablePaths` → `countParquetFilesRecursive()` — a recursive
`readdir` + `statSync` on **every** parquet file under each path, purely to test
`fileCount > 0`, then throws the count away.

On a large store the first History API path request after a restart
synchronously stat-walks millions of files on the main thread.

### Fix

- `getAvailablePaths` gains a `countFiles` flag (default `true`).
- `getAvailablePathsArray` passes `false` and uses a new
  `hasParquetFilesRecursiveSync` that **short-circuits on the first `.parquet`
  found** (Dirent-based, no per-file `statSync`).
- Callers that actually display the count (`/api/paths`, the analyzer prompt)
  keep `countFiles: true` and are unchanged. Same set of paths is returned.

---

## Verified on production (~3.3M files / 51 GB)

Empty-parquet sweep (Fix 1):

| | quarantine step | event loop |
|---|---|---|
| before | 6–20 min, never completed | frozen (100% CPU main thread) |
| after, first run | ~113 s (one-time) | responsive (async I/O) |
| after, incremental | ~18 s | responsive |

## Notes

- New state file: `<dataDir>/.last-empty-sweep` (single timestamp; created on
  first run).
- The very first start after upgrade pays a one-time full sweep to catch
  existing stubs; all subsequent starts are incremental.
