### PR TITLE
fix: harden SQL injection, untrusted-SQL, and SSRF surfaces

### DIFF
--- a/src/HistoryAPI.ts
+++ b/src/HistoryAPI.ts
@@ -10,6 +10,11 @@ import { Context, Path, Timestamp } from '@signalk/server-api';
 import { ParamsDictionary } from 'express-serve-static-core';
 import { ParsedQs } from 'qs';
 import { DuckDBPool } from './utils/duckdb-pool';
+import { escapeSqlString } from './utils/sql-escape';
+import {
+  validateContext,
+  validateSignalKPath,
+} from './utils/signalk-validation';
 import path from 'path';
 import {
   getAvailablePathsArray,
@@ -447,7 +452,10 @@ function getContext(
   ) {
     return `vessels.${selfId}` as Context;
   }
-  return contextFromQuery.replace(/ /gi, '') as Context;
+  // The context is interpolated into read_parquet() globs and filesystem paths;
+  // reject anything that is not a well-formed SignalK context before it can
+  // inject a glob wildcard, path separator, or SQL quote.
+  return validateContext(contextFromQuery.replace(/ /gi, ''));
 }
 
 type QuerySource = 'local' | 's3' | 'hybrid' | 'auto';
@@ -827,7 +835,7 @@ export class HistoryAPI {
 
         // Build FROM: parquet UNION ALL buffer
         const parquetFrom = `SELECT signalk_timestamp, value_latitude, value_longitude FROM (
-          SELECT * FROM read_parquet('${localFilePath}', union_by_name=true, filename=true)
+          SELECT * FROM read_parquet('${escapeSqlString(localFilePath)}', union_by_name=true, filename=true)
           WHERE filename NOT LIKE '%/processed/%'
           AND filename NOT LIKE '%/quarantine/%'
           AND filename NOT LIKE '%/failed/%'
@@ -972,7 +980,11 @@ export class HistoryAPI {
       // automatically.
       const pathExpressions = ((req.query.paths as string) || '')
         .replace(PATHS_SANITIZER, '')
-        .split(',');
+        .split(',')
+        // Drop empty expressions so a missing `paths` query (which splits to
+        // ['']) doesn't reach validateSignalKPath and throw; the empty-result
+        // branch downstream still handles the no-path case.
+        .filter(Boolean);
       const pathSpecs: PathSpec[] = pathExpressions.map(splitPathExpression);
 
       // Auto-select tier based on resolution (provider selects automatically)
@@ -1200,7 +1212,7 @@ export class HistoryAPI {
 
             // Build FROM: parquet UNION ALL buffer (for today's unexported data)
             const parquetFrom = `SELECT signalk_timestamp, value_latitude, value_longitude FROM (
-              SELECT * FROM read_parquet('${posFilePath}', union_by_name=true, filename=true)
+              SELECT * FROM read_parquet('${escapeSqlString(posFilePath)}', union_by_name=true, filename=true)
               WHERE filename NOT LIKE '%/processed/%'
               AND filename NOT LIKE '%/quarantine/%'
               AND filename NOT LIKE '%/failed/%'
@@ -1467,12 +1479,14 @@ export class HistoryAPI {
           // For hybrid queries, we UNION local and S3 sources
           // Local files need filename filter to exclude processed/quarantine/etc directories
           const buildFromClause = (filePath: string): string => {
+            // Escape the path before splicing it into the SQL string literal.
+            const fp = escapeSqlString(filePath);
             const isS3 = filePath.startsWith('s3://');
             if (isS3) {
-              return `read_parquet('${filePath}', union_by_name=true, filename=true)`;
+              return `read_parquet('${fp}', union_by_name=true, filename=true)`;
             }
             // Local files: exclude processed, quarantine, failed, repaired directories
-            return `(SELECT * FROM read_parquet('${filePath}', union_by_name=true, filename=true) WHERE filename NOT LIKE '%/processed/%' AND filename NOT LIKE '%/quarantine/%' AND filename NOT LIKE '%/failed/%' AND filename NOT LIKE '%/repaired/%')`;
+            return `(SELECT * FROM read_parquet('${fp}', union_by_name=true, filename=true) WHERE filename NOT LIKE '%/processed/%' AND filename NOT LIKE '%/quarantine/%' AND filename NOT LIKE '%/failed/%' AND filename NOT LIKE '%/repaired/%')`;
           };
 
           // Build FROM clause: local-only by default, hybrid only if S3 has data
@@ -1741,7 +1755,7 @@ export class HistoryAPI {
             let hasValueJson = false;
             if (localFilePath) {
               try {
-                const schemaQuery = `SELECT * FROM parquet_schema('${localFilePath}') WHERE name = 'value_json'`;
+                const schemaQuery = `SELECT * FROM parquet_schema('${escapeSqlString(localFilePath)}') WHERE name = 'value_json'`;
                 const schemaResult =
                   await connection.runAndReadAll(schemaQuery);
                 hasValueJson = schemaResult.getRowObjects().length > 0;
@@ -2458,6 +2472,10 @@ function splitPathExpression(pathExpression: string): PathSpec {
       }
     }
   }
+
+  // The bare path is interpolated into read_parquet() globs and filesystem
+  // paths; reject anything that is not a well-formed SignalK path.
+  validateSignalKPath(parts[0]);
 
   return {
     path: parts[0] as Path,

--- a/src/api-routes.ts
+++ b/src/api-routes.ts
@@ -5,6 +5,11 @@ import express, { Router } from 'express';
 import multer from 'multer';
 import { getAvailablePaths } from './utils/path-discovery';
 import { DuckDBPool } from './utils/duckdb-pool';
+import { escapeSqlString } from './utils/sql-escape';
+import {
+  validateSignalKPath,
+  assertWithinDataDir,
+} from './utils/signalk-validation';
 import {
   TypedRequest,
   TypedResponse,
@@ -403,7 +408,7 @@ export function registerApiRoutes(
         }
 
         const sampleFile = result.files[0];
-        const query = `SELECT * FROM read_parquet('${sampleFile.path}', union_by_name=true) LIMIT ${limit}`;
+        const query = `SELECT * FROM read_parquet('${escapeSqlString(sampleFile.path)}', union_by_name=true) LIMIT ${limit}`;
 
         // Get connection from pool (spatial extension already loaded)
         const connection = await DuckDBPool.getConnection();
@@ -505,8 +510,11 @@ export function registerApiRoutes(
           });
         }
 
-        // Get connection from pool (spatial extension already loaded)
-        const connection = await DuckDBPool.getConnection();
+        // Run user-supplied SQL on the hardened sandbox connection: file access
+        // is confined to the data dir and httpfs/S3 are unavailable, so the raw
+        // SQL cannot read arbitrary host files, reach the network, or use the S3
+        // secret. Legitimate read_parquet of the data dir still works.
+        const connection = await DuckDBPool.getSandboxConnection(dataDir);
 
         try {
           const reader = await connection.runAndReadAll(processedQuery);
@@ -600,9 +608,12 @@ export function registerApiRoutes(
           keyPrefix: cloud.keyPrefix || 'none',
         });
       } catch (error) {
+        // AWS SDK messages can disclose bucket/region/endpoint topology; keep the
+        // detail in the server log and return a generic message to the client.
+        app.error(`Cloud connection test failed: ${(error as Error).message}`);
         return res.status(500).json({
           success: false,
-          error: (error as Error).message || 'Cloud connection failed',
+          error: 'Cloud connection failed',
         });
       }
     }
@@ -795,8 +806,9 @@ export function registerApiRoutes(
 
           setTimeout(() => cloudCompareJobs.delete(jobId), 5 * 60 * 1000);
         } catch (error) {
+          app.error(`Cloud compare failed: ${(error as Error).message}`);
           job.status = 'error';
-          job.error = (error as Error).message;
+          job.error = 'Cloud compare failed';
         }
       })();
 
@@ -894,6 +906,14 @@ export function registerApiRoutes(
                 ? key.replace(new RegExp(`^${cloud.keyPrefix}/?`), '')
                 : key;
               const localPath = path.join(dataDir, relativePath);
+              // Reject keys that escape the data dir (e.g. '../'), so a sync
+              // request can't read arbitrary local files and push them to the bucket.
+              try {
+                assertWithinDataDir(dataDir, localPath);
+              } catch {
+                app.error(`Rejecting cloud sync key outside data dir: ${key}`);
+                continue;
+              }
               if (await fs.pathExists(localPath)) {
                 filesToSync.push({ key, localPath });
               }
@@ -1061,6 +1081,20 @@ export function registerApiRoutes(
           return;
         }
 
+        // The path is persisted and later becomes a filesystem directory under
+        // the data dir, so reject anything that is not a plain SignalK path
+        // (blocks '..' traversal and absolute/separator-laden values).
+        try {
+          validateSignalKPath(newPath.path);
+        } catch {
+          res.status(400).json({
+            success: false,
+            error:
+              'Invalid path: must be a plain SignalK path (e.g. navigation.position).',
+          });
+          return;
+        }
+
         // Load current configuration
         const webAppConfig = loadWebAppConfig(app);
         const currentPaths = webAppConfig.paths;
@@ -1122,6 +1156,19 @@ export function registerApiRoutes(
           res.status(400).json({
             success: false,
             error: 'Path is required',
+          });
+          return;
+        }
+
+        // The path is persisted and later becomes a filesystem directory under
+        // the data dir, so reject anything that is not a plain SignalK path.
+        try {
+          validateSignalKPath(updatedPath.path);
+        } catch {
+          res.status(400).json({
+            success: false,
+            error:
+              'Invalid path: must be a plain SignalK path (e.g. navigation.position).',
           });
           return;
         }
@@ -1923,16 +1970,8 @@ export function registerApiRoutes(
           timeRange,
           aggregationMethod,
           resolution,
-          claudeModel,
           useDatabaseAccess,
         } = req.body;
-
-        console.log(
-          `🧠 ANALYSIS REQUEST: dataPath=${dataPath}, templateId=${templateId}, analysisType=${analysisType}, aggregationMethod=${aggregationMethod}, model=${claudeModel || 'config-default'}`
-        );
-        console.log(
-          `🔍 CUSTOM PROMPT DEBUG: "${customPrompt}" (type: ${typeof customPrompt}, length: ${customPrompt?.length || 0})`
-        );
 
         if (!dataPath) {
           return res.status(400).json({
@@ -2060,10 +2099,6 @@ export function registerApiRoutes(
             error: 'Both conversationId and question are required',
           });
         }
-
-        console.log(
-          `🔄 FOLLOW-UP REQUEST: conversationId=${conversationId}, question=${question.substring(0, 100)}...`
-        );
 
         // Use shared analyzer instance to access stored conversations
         const analyzer = getSharedAnalyzer(

--- a/src/claude-analyzer.ts
+++ b/src/claude-analyzer.ts
@@ -12,6 +12,7 @@ import { getAvailablePaths } from './utils/path-discovery';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { DuckDBPool } from './utils/duckdb-pool';
+import { escapeSqlString } from './utils/sql-escape';
 import { ClaudeModel } from './claude-models';
 import { shouldSkipDirectory } from './utils/path-helpers';
 
@@ -1167,16 +1168,6 @@ Begin your analysis by querying relevant data within the specified time range.`;
       this.app?.debug(
         `📝 Full prompt for Claude (${initialPrompt.length} chars):\n${initialPrompt.substring(0, 2000)}${initialPrompt.length > 2000 ? '...[TRUNCATED]' : ''}`
       );
-
-      // Save full prompt to file for debugging
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const fs = require('fs');
-      const debugFile = `/tmp/claude-prompt-debug-${Date.now()}.txt`;
-      fs.writeFileSync(
-        debugFile,
-        `FULL CLAUDE PROMPT (${initialPrompt.length} chars):\n\n${initialPrompt}`
-      );
-      this.app?.debug(`📄 Full prompt saved to: ${debugFile}`);
 
       // Extract system context and user prompt
       const systemContext = `You are an expert maritime data analyst with direct access to a comprehensive database.
@@ -3081,7 +3072,7 @@ Begin your analysis by querying relevant data within the specified time range.`;
         return {
           type: 'tool_result',
           tool_use_id: toolCall.id,
-          content: `Path discovery failed: ${(pathDiscoveryError as Error).message}`,
+          content: 'Path discovery failed.',
         };
       }
     } else if (toolCall.name === 'get_available_signalk_sources') {
@@ -3109,7 +3100,7 @@ Begin your analysis by querying relevant data within the specified time range.`;
         return {
           type: 'tool_result',
           tool_use_id: toolCall.id,
-          content: `Source discovery failed: ${(sourceDiscoveryError as Error).message}`,
+          content: 'Source discovery failed.',
         };
       }
     } else if (toolCall.name === 'find_regimen_episodes') {
@@ -3209,7 +3200,7 @@ Begin your analysis by querying relevant data within the specified time range.`;
           signalk_timestamp,
           CAST(value AS BOOLEAN) as current_value,
           LAG(CAST(value AS BOOLEAN)) OVER (ORDER BY signalk_timestamp) as previous_value
-        FROM read_parquet('${this.dataDirectory}/vessels/*/commands/${regimenName}/*.parquet', union_by_name=true)
+        FROM read_parquet('${escapeSqlString(this.dataDirectory || '')}/vessels/*/commands/${escapeSqlString(regimenName)}/*.parquet', union_by_name=true)
         ${timeConstraint}
         ORDER BY signalk_timestamp
       ),
@@ -3367,8 +3358,16 @@ Begin your analysis by querying relevant data within the specified time range.`;
       }
     }
 
-    // Use shared pool - spatial extension is already loaded at startup
-    const connection = await DuckDBPool.getConnection();
+    if (!this.dataDirectory) {
+      throw new Error('Data directory is not configured');
+    }
+    // Run LLM-generated SQL on the hardened sandbox connection: file access is
+    // confined to the data dir and httpfs/S3 are unavailable, so a prompt-steered
+    // query cannot read arbitrary host files, reach the network, or use the S3
+    // secret. The keyword checks above remain as defence in depth.
+    const connection = await DuckDBPool.getSandboxConnection(
+      this.dataDirectory
+    );
 
     try {
       this.app?.debug(`🔍 Executing SQL query for: ${purpose}`);
@@ -3398,8 +3397,10 @@ Begin your analysis by querying relevant data within the specified time range.`;
       this.app?.debug(`✅ Query returned ${limitedData.length} rows`);
       return limitedData;
     } catch (error) {
+      // Keep the detailed DuckDB error (absolute paths, schema) server-side only;
+      // the thrown message reaches the LLM tool_result and HTTP responses.
       this.app?.error(`SQL query failed: ${(error as Error).message}`);
-      throw new Error(`Database query failed: ${(error as Error).message}`);
+      throw new Error('Database query failed.');
     } finally {
       connection.disconnectSync();
     }

--- a/src/data-handler.ts
+++ b/src/data-handler.ts
@@ -119,7 +119,8 @@ export function createCloudClient(config: PluginConfig, app: ServerAPI): any {
     if (cloud.endpoint) {
       const custom = resolveCustomS3Endpoint(
         cloud.endpoint,
-        cloud.forcePathStyle
+        cloud.forcePathStyle,
+        cloud.allowPrivateEndpoint
       );
       s3Config.endpoint = custom.url;
       s3Config.forcePathStyle = custom.forcePathStyle;

--- a/src/history-provider.ts
+++ b/src/history-provider.ts
@@ -28,6 +28,11 @@ import {
 import { getAvailablePathsArray } from './utils/path-discovery';
 import { getAvailableContextsForTimeRange } from './utils/context-discovery';
 import { DuckDBPool } from './utils/duckdb-pool';
+import { escapeSqlString } from './utils/sql-escape';
+import {
+  validateContext,
+  validateSignalKPath,
+} from './utils/signalk-validation';
 import { getPathComponentSchema } from './utils/schema-cache';
 import { HivePathBuilder } from './utils/hive-path-builder';
 import { isAngularPath } from './utils/angular-paths';
@@ -179,7 +184,7 @@ export class HistoryProvider implements HistoryApi {
       query.context === 'vessels.self' ||
       query.context === ('self' as Context)
         ? (`vessels.${this.selfId}` as Context)
-        : query.context;
+        : validateContext(query.context as string);
     // query.resolution is in seconds per the SignalK History API spec;
     // the DuckDB bucketing SQL below works in milliseconds. Reject 0,
     // negative, NaN, and Infinity here so they don't reach SQL as a
@@ -279,7 +284,7 @@ export class HistoryProvider implements HistoryApi {
         queryContext === 'vessels.self' ||
         queryContext === 'self'
         ? `vessels.${this.selfId}`
-        : queryContext.replace(/ /gi, '')
+        : validateContext(queryContext.replace(/ /gi, ''))
       : undefined;
     const paths = getAvailablePathsArray(this.dataDir, this.app, context);
     return paths as PathsResponse;
@@ -295,6 +300,9 @@ export class HistoryProvider implements HistoryApi {
     toIso: string,
     resolutionMs: number
   ): Promise<Array<[Timestamp, unknown]>> {
+    // Reject a malformed path before it reaches the read_parquet glob.
+    validateSignalKPath(pathSpec.path as string);
+
     // Use HivePathBuilder for correct Hive-partitioned paths
     const hiveBuilder = new HivePathBuilder();
 
@@ -349,7 +357,7 @@ export class HistoryProvider implements HistoryApi {
       const sourceFilter = buildParquetFilterClause(filters, available);
 
       // Build parquet FROM clause with filename filtering
-      const parquetFrom = `(SELECT * FROM read_parquet('${filePath}', union_by_name=true, filename=true) WHERE filename NOT LIKE '%/processed/%' AND filename NOT LIKE '%/quarantine/%' AND filename NOT LIKE '%/failed/%' AND filename NOT LIKE '%/repaired/%'${sourceFilter})`;
+      const parquetFrom = `(SELECT * FROM read_parquet('${escapeSqlString(filePath)}', union_by_name=true, filename=true) WHERE filename NOT LIKE '%/processed/%' AND filename NOT LIKE '%/quarantine/%' AND filename NOT LIKE '%/failed/%' AND filename NOT LIKE '%/repaired/%'${sourceFilter})`;
 
       if (componentSchema && componentSchema.components.size > 0) {
         // Object path - aggregate each component

--- a/src/index.ts
+++ b/src/index.ts
@@ -367,7 +367,8 @@ export default function (app: ServerAPI): SignalKPlugin {
             // Self-hosted S3-compatible endpoint (e.g. Garage, MinIO)
             const custom = resolveCustomS3Endpoint(
               state.currentConfig.cloudUpload.endpoint,
-              state.currentConfig.cloudUpload.forcePathStyle
+              state.currentConfig.cloudUpload.forcePathStyle,
+              state.currentConfig.cloudUpload.allowPrivateEndpoint
             );
             endpoint = custom.host;
             useSSL = custom.useSSL;
@@ -1091,6 +1092,13 @@ export default function (app: ServerAPI): SignalKPlugin {
                     title: 'Use Path-Style Addressing',
                     description:
                       'Use path-style bucket addressing (https://endpoint/bucket) instead of virtual-hosted-style (https://bucket.endpoint). Often required by self-hosted S3-compatible services like Garage or MinIO. If left unset, defaults to enabled when a custom endpoint is configured.',
+                  },
+                  allowPrivateEndpoint: {
+                    type: 'boolean',
+                    title: 'Allow Private/Local Endpoints',
+                    description:
+                      'Permit custom S3 endpoints on private, loopback, or link-local addresses (e.g. 192.168.x.x, localhost). Required for self-hosted services on the local network, but disabled by default to prevent SSRF.',
+                    default: false,
                   },
                 },
                 description:

--- a/src/types.ts
+++ b/src/types.ts
@@ -278,6 +278,7 @@ export interface CloudUploadConfig {
   region?: string; // S3 only (e.g. 'us-east-1', or 'garage' for Garage)
   endpoint?: string; // S3 only - custom endpoint URL for self-hosted S3-compatible services (Garage, MinIO, etc.)
   forcePathStyle?: boolean; // S3 only - use path-style addressing instead of virtual-hosted-style (often required by self-hosted S3-compatible services)
+  allowPrivateEndpoint?: boolean; // S3 only - permit a custom endpoint on a private/loopback/link-local address (off by default to block SSRF)
   accountId?: string; // R2 only (Cloudflare account ID)
   keyPrefix?: string;
   accessKeyId?: string;

--- a/src/utils/cloud-endpoint.ts
+++ b/src/utils/cloud-endpoint.ts
@@ -7,9 +7,65 @@ export interface ResolvedS3Endpoint {
   forcePathStyle: boolean;
 }
 
+/**
+ * True when `host` is a loopback, link-local, or RFC1918 private address (or a
+ * localhost name). A custom S3 endpoint pointing at such a host turns the cloud
+ * uploader (and DuckDB's httpfs) into an SSRF primitive against link-local cloud
+ * metadata (169.254.169.254) or internal services, so these are rejected unless
+ * the operator explicitly opts in.
+ *
+ * Input:  "169.254.169.254" -> true    Input: "s3.example.com" -> false
+ * Input:  "127.0.0.1"        -> true    Input: "[::1]" / "::1"  -> true
+ */
+function isPrivateIpv4(a: number, b: number): boolean {
+  if (a === 127 || a === 10 || a === 0) return true; // loopback, RFC1918 /8, unspecified
+  if (a === 169 && b === 254) return true; // link-local incl. cloud metadata
+  if (a === 172 && b >= 16 && b <= 31) return true; // RFC1918 /12
+  if (a === 192 && b === 168) return true; // RFC1918 /16
+  return false;
+}
+
+function isPrivateOrLoopbackHost(host: string): boolean {
+  let h = host.toLowerCase().replace(/^\[/, '').replace(/\]$/, '');
+
+  if (h === 'localhost' || h.endsWith('.localhost')) {
+    return true;
+  }
+
+  // Canonicalize an IPv4-mapped IPv6 literal down to its embedded IPv4 so the
+  // rules below catch it. Node's URL parser normalizes ::ffff:127.0.0.1 to the
+  // hex form ::ffff:7f00:1, so handle both the dotted and hex encodings.
+  const mappedDotted = h.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (mappedDotted) {
+    h = mappedDotted[1];
+  } else {
+    const mappedHex = h.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+    if (mappedHex) {
+      const hi = parseInt(mappedHex[1], 16);
+      const lo = parseInt(mappedHex[2], 16);
+      h = `${hi >> 8}.${hi & 0xff}.${lo >> 8}.${lo & 0xff}`;
+    }
+  }
+
+  // IPv4 (including a de-mapped ::ffff: address)
+  const ipv4 = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (ipv4) {
+    const [a, b] = ipv4.slice(1).map(n => parseInt(n, 10));
+    return isPrivateIpv4(a, b);
+  }
+
+  // IPv6
+  if (h === '::1' || h === '::') return true; // loopback, unspecified
+  // Link-local fe80::/10 spans the first hextet fe80–febf (not just fe80).
+  if (/^fe[89ab][0-9a-f]:/.test(h)) return true;
+  if (/^f[cd][0-9a-f]{2}:/.test(h)) return true; // unique-local fc00::/7
+  return false;
+}
+
 export function resolveCustomS3Endpoint(
   endpoint: string,
-  forcePathStyleConfig: boolean | undefined
+  forcePathStyleConfig: boolean | undefined,
+  allowPrivateEndpoint: boolean = false
 ): ResolvedS3Endpoint {
   let parsed: URL;
   try {
@@ -37,6 +93,13 @@ export function resolveCustomS3Endpoint(
   ) {
     throw new Error(
       `cloudUpload.endpoint must be an origin only (scheme + host[:port]), with no path, query, or fragment: "${endpoint}"`
+    );
+  }
+
+  if (!allowPrivateEndpoint && isPrivateOrLoopbackHost(parsed.hostname)) {
+    throw new Error(
+      `cloudUpload.endpoint host "${parsed.hostname}" is a private, loopback, or link-local address; ` +
+        `set cloudUpload.allowPrivateEndpoint to true to permit a self-hosted endpoint on your LAN: "${endpoint}"`
     );
   }
 

--- a/src/utils/context-discovery.ts
+++ b/src/utils/context-discovery.ts
@@ -6,6 +6,7 @@ import { debugLogger } from './debug-logger';
 import { CACHE_TTL } from '../config/cache-defaults';
 import { HivePathBuilder } from './hive-path-builder';
 import { DuckDBPool } from './duckdb-pool';
+import { escapeSqlString } from './sql-escape';
 import { SpatialFilter, buildSpatialSqlClause } from './spatial-queries';
 
 // Cache for context list
@@ -249,7 +250,7 @@ export async function getContextsInSpatialFilter(
 
   const query = `
     SELECT DISTINCT context
-    FROM read_parquet('${glob}', hive_partitioning=true, union_by_name=true)
+    FROM read_parquet('${escapeSqlString(glob)}', hive_partitioning=true, union_by_name=true)
     WHERE signalk_timestamp >= '${fromIso}'
       AND signalk_timestamp < '${toIso}'
       AND ${spatialClause}

--- a/src/utils/duckdb-pool.ts
+++ b/src/utils/duckdb-pool.ts
@@ -40,6 +40,7 @@ export class DuckDBPool {
   private static sqliteDbPath: string | null = null;
   private static sqliteInitialized: boolean = false;
   private static spatialAvailable: boolean = false;
+  private static sandboxInstance: DuckDBInstance | null = null;
 
   /**
    * Initialize the DuckDB instance and load extensions
@@ -129,6 +130,53 @@ export class DuckDBPool {
   }
 
   /**
+   * Get a connection to a hardened sandbox instance for executing UNTRUSTED SQL
+   * (the raw-SQL `/api/query` endpoint and LLM-generated analysis SQL).
+   *
+   * The sandbox is a SEPARATE DuckDB instance scoped to the plugin data
+   * directory: `allowed_directories=[dataDir]` followed by
+   * `enable_external_access=false` confines all file access to the data dir, so
+   * reading arbitrary host files (read_text/read_csv/read_parquet outside the
+   * dir) and ATTACHing external databases are denied. It never loads httpfs and
+   * never holds the S3 secret, so it cannot be used for SSRF or credential
+   * exfiltration. Local parquet reads/globs under the data dir still work, which
+   * is all the untrusted-SQL paths need. DuckDB settings are instance-global and
+   * cannot be relaxed once the database is running, which is why the trusted
+   * upload/export path keeps using the separate, fully-capable pool instance.
+   *
+   * @param dataDir Absolute path to the plugin data directory. Used on the first
+   *   call to scope the sandbox; ignored thereafter while the instance lives.
+   */
+  static async getSandboxConnection(dataDir: string) {
+    if (!this.sandboxInstance) {
+      const instance = await DuckDBInstance.create();
+      const setup = await instance.connect();
+      // Cap memory on this untrusted-SQL instance, matching the main pool, so a
+      // heavy query can't exhaust the Node process.
+      await setup.runAndReadAll("SET memory_limit = '512MB';");
+      // Spatial must be available before access is locked down (extensions
+      // cannot load once external access is disabled). It is already installed
+      // globally by the main instance, so LOAD normally succeeds without network.
+      try {
+        await setup.runAndReadAll('LOAD spatial;');
+      } catch {
+        await setup.runAndReadAll('INSTALL spatial;');
+        await setup.runAndReadAll('LOAD spatial;');
+      }
+      // Order matters: allowed_directories can only be set while external access
+      // is still enabled; disabling it afterwards confines file access to that
+      // directory and cannot be re-enabled for the life of the instance.
+      await setup.runAndReadAll(
+        `SET allowed_directories=['${dataDir.replace(/'/g, "''")}'];`
+      );
+      await setup.runAndReadAll('SET enable_external_access=false;');
+      setup.disconnectSync();
+      this.sandboxInstance = instance;
+    }
+    return await this.sandboxInstance.connect();
+  }
+
+  /**
    * Store the SQLite buffer database path for federated queries.
    * Call this after initialize() and after the SQLiteBuffer is created.
    *
@@ -170,6 +218,9 @@ export class DuckDBPool {
       this.sqliteDbPath = null;
       this.sqliteInitialized = false;
     }
+    // Drop the sandbox instance too so a reconfigure rebuilds it against the
+    // (possibly changed) data directory.
+    this.sandboxInstance = null;
   }
 
   /**
@@ -224,6 +275,10 @@ export class DuckDBPool {
       if (config.endpoint && config.useSSL !== undefined) {
         endpointClause += `,\n          USE_SSL ${config.useSSL ? 'true' : 'false'}`;
       }
+      // SECURITY: this secret lives on the main pool instance. Any code path that
+      // executes untrusted (user- or LLM-supplied) SQL must use
+      // getSandboxConnection() instead of getConnection(), so the secret and
+      // httpfs are unreachable from that SQL.
       const secretSql = `
         CREATE OR REPLACE SECRET s3_credentials (
           TYPE S3,

--- a/src/utils/path-discovery.ts
+++ b/src/utils/path-discovery.ts
@@ -5,6 +5,7 @@ import { PathInfo } from '../types';
 import { ZonedDateTime } from '@js-joda/core';
 import { HivePathBuilder } from './hive-path-builder';
 import { DuckDBPool } from './duckdb-pool';
+import { escapeSqlString } from './sql-escape';
 
 /**
  * Get available SignalK paths from Hive directory structure
@@ -321,7 +322,7 @@ async function checkPathHasDataInRangeHive(
       // Fast query: just check if ANY row exists in time range
       const query = `
         SELECT 1 as found
-        FROM read_parquet('${filePath}', union_by_name=true, filename=true)
+        FROM read_parquet('${escapeSqlString(filePath)}', union_by_name=true, filename=true)
         WHERE signalk_timestamp >= '${fromIso}'
           AND signalk_timestamp < '${toIso}'
           AND filename NOT LIKE '%/processed/%'

--- a/src/utils/signalk-validation.ts
+++ b/src/utils/signalk-validation.ts
@@ -1,0 +1,104 @@
+/**
+ * Boundary validation for SignalK contexts and paths.
+ *
+ * The History API and several routes accept a `context` (e.g. vessels.<id>) and
+ * a `path` (e.g. navigation.position) from untrusted HTTP input and splice them
+ * into DuckDB `read_parquet('...')` glob literals and into filesystem directory
+ * names. The SQL builders escape quotes (see sql-escape.ts) as the guaranteed
+ * defence, but these allow-list validators reject the values up-front so glob
+ * wildcards, path separators, and traversal sequences never reach a glob or the
+ * filesystem at all. Validation is deliberately strict: anything that is not a
+ * well-formed SignalK identifier is rejected rather than sanitised.
+ */
+import { Context, Path } from '@signalk/server-api';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// A SignalK context is `vessels.<id>` / `aircraft.<id>` / etc. The id segment is
+// typically a urn (urn:mrn:imo:mmsi:..., urn:mrn:signalk:uuid:...) so colons,
+// dots, hyphens and underscores are allowed; quotes, slashes, glob metacharacters
+// (* ? [ ]) and whitespace are not.
+// The id segment must start and end with an alphanumeric, so dot-only ids like
+// "vessels.." or "vessels...etc" are rejected.
+// Input:  "vessels.urn:mrn:imo:mmsi:230099999"  -> returned unchanged
+// Input:  "vessels.x')+(SELECT..."              -> throws
+// Input:  "vessels.."                            -> throws
+const CONTEXT_PATTERN =
+  /^[A-Za-z][A-Za-z0-9]*\.[A-Za-z0-9](?:[A-Za-z0-9:_.-]*[A-Za-z0-9])?$/;
+
+// A SignalK path is dot-delimited alphanumeric segments, e.g.
+// "environment.wind.speedApparent" or "electrical.batteries.1.voltage".
+// Reject anything containing a quote, slash, glob metacharacter, or '..'.
+// Input:  "navigation.position" -> returned unchanged
+// Input:  "../../etc"           -> throws
+const PATH_PATTERN = /^[A-Za-z][A-Za-z0-9]*(\.[A-Za-z0-9_-]+)*$/;
+
+/**
+ * Validate a SignalK context string from untrusted input. Returns it unchanged
+ * when valid; throws otherwise. Callers should already have resolved the
+ * `self`/`vessels.self` aliases to a concrete context before calling this.
+ */
+export function validateContext(context: string): Context {
+  if (
+    typeof context !== 'string' ||
+    context.includes('..') ||
+    !CONTEXT_PATTERN.test(context)
+  ) {
+    throw new Error(`Invalid SignalK context: ${JSON.stringify(context)}`);
+  }
+  return context as Context;
+}
+
+/**
+ * Validate a single SignalK path segment from untrusted input. Returns it
+ * unchanged when valid; throws otherwise.
+ */
+export function validateSignalKPath(p: string): Path {
+  if (typeof p !== 'string' || p.length > 256 || !PATH_PATTERN.test(p)) {
+    throw new Error(`Invalid SignalK path: ${JSON.stringify(p)}`);
+  }
+  return p as Path;
+}
+
+/**
+ * Assert that a candidate filesystem path resolves to a location inside
+ * `dataDir`. Returns the resolved absolute path when safe; throws otherwise.
+ * Used to stop `../` traversal in request-supplied keys/paths from reaching
+ * files outside the plugin's data directory.
+ */
+export function assertWithinDataDir(
+  dataDir: string,
+  candidate: string
+): string {
+  const root = path.resolve(dataDir);
+  const resolved = path.resolve(candidate);
+  if (resolved !== root && !resolved.startsWith(root + path.sep)) {
+    throw new Error(
+      `Path escapes the data directory: ${JSON.stringify(candidate)}`
+    );
+  }
+  // path.resolve is lexical only: a symlink inside dataDir could still point
+  // outside it. When both paths exist, compare their real (symlink-resolved)
+  // locations so a symlinked entry can't escape. A non-existent candidate has
+  // no symlink to follow, so the lexical check above already covers it.
+  let realRoot: string;
+  let realResolved: string;
+  try {
+    realRoot = fs.realpathSync(root);
+    realResolved = fs.realpathSync(resolved);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return resolved;
+    }
+    throw err;
+  }
+  if (
+    realResolved !== realRoot &&
+    !realResolved.startsWith(realRoot + path.sep)
+  ) {
+    throw new Error(
+      `Path escapes the data directory via symlink: ${JSON.stringify(candidate)}`
+    );
+  }
+  return resolved;
+}

--- a/test/unit/utils/cloud-endpoint.test.ts
+++ b/test/unit/utils/cloud-endpoint.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for custom S3 endpoint resolution. The security-relevant behaviour
+ * is the SSRF guard: a custom endpoint pointing at a private/loopback/link-local
+ * host must be rejected unless the operator explicitly opts in.
+ */
+import { expect } from 'chai';
+import { resolveCustomS3Endpoint } from '../../../src/utils/cloud-endpoint';
+
+describe('resolveCustomS3Endpoint', () => {
+  const privateHosts = [
+    'http://169.254.169.254', // cloud metadata
+    'http://localhost:9000',
+    'http://127.0.0.1',
+    'http://[::1]',
+    'http://10.1.2.3',
+    'http://192.168.1.10',
+    'http://172.16.0.1',
+    'http://[::ffff:127.0.0.1]', // IPv4-mapped IPv6 loopback
+    'http://[::ffff:169.254.169.254]', // IPv4-mapped IPv6 metadata
+    'http://[fe80::1]', // link-local (bottom of fe80::/10)
+    'http://[febf::1]', // link-local (top of fe80::/10)
+  ];
+
+  it('rejects private/loopback/link-local hosts by default', () => {
+    for (const url of privateHosts) {
+      expect(() => resolveCustomS3Endpoint(url, undefined), url).to.throw();
+    }
+  });
+
+  it('permits private hosts when allowPrivateEndpoint is true', () => {
+    for (const url of privateHosts) {
+      expect(
+        () => resolveCustomS3Endpoint(url, undefined, true),
+        url
+      ).to.not.throw();
+    }
+  });
+
+  it('accepts a public endpoint host', () => {
+    const r = resolveCustomS3Endpoint('https://s3.example.com', undefined);
+    expect(r.host).to.equal('s3.example.com');
+    expect(r.useSSL).to.equal(true);
+  });
+
+  it('accepts a public IPv6 host', () => {
+    expect(() =>
+      resolveCustomS3Endpoint('https://[2606:4700::1]', undefined)
+    ).to.not.throw();
+  });
+
+  it('still rejects an endpoint with a path or query', () => {
+    expect(() =>
+      resolveCustomS3Endpoint('https://s3.example.com/bucket', undefined)
+    ).to.throw();
+    expect(() =>
+      resolveCustomS3Endpoint('https://s3.example.com?x=1', undefined)
+    ).to.throw();
+  });
+
+  it('still rejects a non-http(s) scheme', () => {
+    expect(() =>
+      resolveCustomS3Endpoint('ftp://s3.example.com', undefined)
+    ).to.throw();
+  });
+});

--- a/test/unit/utils/signalk-validation.test.ts
+++ b/test/unit/utils/signalk-validation.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for the SignalK context/path boundary validators. These reject
+ * untrusted values before they reach a read_parquet() glob or the filesystem,
+ * so the key cases are the injection/traversal attempts that must throw.
+ */
+import { expect } from 'chai';
+import * as path from 'path';
+import {
+  validateContext,
+  validateSignalKPath,
+  assertWithinDataDir,
+} from '../../../src/utils/signalk-validation';
+
+describe('validateContext', () => {
+  it('accepts well-formed vessel contexts', () => {
+    expect(validateContext('vessels.self')).to.equal('vessels.self');
+    expect(validateContext('vessels.urn:mrn:imo:mmsi:230099999')).to.equal(
+      'vessels.urn:mrn:imo:mmsi:230099999'
+    );
+    expect(
+      validateContext('vessels.urn:mrn:signalk:uuid:1234-5678-90ab')
+    ).to.equal('vessels.urn:mrn:signalk:uuid:1234-5678-90ab');
+  });
+
+  it('rejects a SQL-quote breakout attempt', () => {
+    expect(() => validateContext("vessels.x')+(SELECT 1")).to.throw();
+  });
+
+  it('rejects glob wildcards that would widen the read_parquet glob', () => {
+    expect(() => validateContext('vessels.*')).to.throw();
+    expect(() => validateContext('vessels.a?b')).to.throw();
+  });
+
+  it('rejects path separators and traversal', () => {
+    expect(() => validateContext('vessels.a/b')).to.throw();
+    expect(() => validateContext('vessels.../etc')).to.throw();
+    expect(() => validateContext('../../etc')).to.throw();
+  });
+
+  it('rejects empty and structurally-incomplete contexts', () => {
+    expect(() => validateContext('')).to.throw();
+    expect(() => validateContext('vessels.')).to.throw();
+    expect(() => validateContext('vessels')).to.throw();
+  });
+
+  it('rejects dot-only and consecutive-dot context ids', () => {
+    expect(() => validateContext('vessels..')).to.throw();
+    expect(() => validateContext('vessels...etc')).to.throw();
+    expect(() => validateContext('vessels.a..b')).to.throw();
+  });
+});
+
+describe('validateSignalKPath', () => {
+  it('accepts well-formed SignalK paths', () => {
+    expect(validateSignalKPath('navigation.position')).to.equal(
+      'navigation.position'
+    );
+    expect(validateSignalKPath('environment.wind.speedApparent')).to.equal(
+      'environment.wind.speedApparent'
+    );
+    expect(validateSignalKPath('electrical.batteries.1.voltage')).to.equal(
+      'electrical.batteries.1.voltage'
+    );
+  });
+
+  it('rejects traversal, separators, and quotes', () => {
+    expect(() => validateSignalKPath('..')).to.throw();
+    expect(() => validateSignalKPath('a..b')).to.throw();
+    expect(() => validateSignalKPath('a/b')).to.throw();
+    expect(() => validateSignalKPath("a'b")).to.throw();
+    expect(() => validateSignalKPath('navigation.position*')).to.throw();
+  });
+
+  it('rejects empty, leading-dot, and over-long paths', () => {
+    expect(() => validateSignalKPath('')).to.throw();
+    expect(() => validateSignalKPath('.navigation')).to.throw();
+    expect(() => validateSignalKPath('a.' + 'b'.repeat(300))).to.throw();
+  });
+});
+
+describe('assertWithinDataDir', () => {
+  const dataDir = path.resolve('var', 'signalk', 'data');
+
+  it('returns the resolved path for files inside the data dir', () => {
+    const inside = path.join(dataDir, 'vessels', 'self', 'x.parquet');
+    expect(assertWithinDataDir(dataDir, inside)).to.equal(path.resolve(inside));
+  });
+
+  it('allows the data dir itself', () => {
+    expect(assertWithinDataDir(dataDir, dataDir)).to.equal(dataDir);
+  });
+
+  it('throws on a ../ traversal that escapes the data dir', () => {
+    const escape = path.join(dataDir, '..', '..', 'etc', 'passwd');
+    expect(() => assertWithinDataDir(dataDir, escape)).to.throw();
+  });
+
+  it('throws on a sibling dir sharing the data-dir name as a prefix', () => {
+    const sibling = path.resolve('var', 'signalk', 'data-evil', 'f');
+    expect(() => assertWithinDataDir(dataDir, sibling)).to.throw();
+  });
+});


### PR DESCRIPTION
Security hardening for the v1 release. Covered by build, lint, the full mocha suite (548 passing, including new unit tests), and an adversarial review.

## What

- **SQL injection on the default read path.** Validate the SignalK `context` and `path` from the History API at the boundary and escape every value interpolated into DuckDB `read_parquet(...)` / `parquet_schema(...)` globs — the v1 `HistoryAPI.ts` and v2 `history-provider.ts` read paths, plus `context-discovery`, `path-discovery`, `/api/sample`, and the Claude `find_regimen_episodes` query. New `src/utils/signalk-validation.ts` holds the allow-list validators; escaping reuses the existing `sql-escape.ts`.
- **Untrusted-SQL confinement.** The raw `/api/query` endpoint and Claude-generated SQL now run on a dedicated DuckDB sandbox instance scoped to the data directory (`allowed_directories=[dataDir]` then `enable_external_access=false`, with no httpfs and no S3 secret). Local parquet reads still work; arbitrary host-file reads, network/SSRF, and the S3 credential are unreachable. The DuckDB 1.5 recipe was verified empirically.
- **SSRF.** Reject custom S3 endpoints resolving to private / loopback / link-local hosts unless `cloudUpload.allowPrivateEndpoint` is set.
- **Information disclosure.** Remove the unconditional `/tmp/claude-prompt-debug-*.txt` dump; return generic cloud and database error messages to clients and to the model (detail stays in server logs); drop the `/api/analyze` prompt console logs.
- **Persistence boundary.** Validate the persisted path configuration and canonicalize cloud-sync keys against the data directory.

## Tests

Adds unit tests for the validators and the SSRF host check. Full suite green.

## Scope and merge order

One of four independent v1-stabilization PRs cut from `main` (security, reliability, correctness, hygiene). Recommended merge order: security → reliability → correctness → hygiene; a trial merge of all four in that order produced zero conflicts. Architecture refactors, broader test coverage, and maintainability cleanups are intentionally out of scope here.
