### PR TITLE
fix: correct query results and prevent silent data drops

### DIFF
--- a/src/HistoryAPI.ts
+++ b/src/HistoryAPI.ts
@@ -405,7 +405,15 @@ function hasTimezoneInfo(dateTimeStr: string): boolean {
 function parseDateTime(dateTimeStr: string): ZonedDateTime {
   // Normalize the datetime string to include seconds if missing
   let normalizedStr = dateTimeStr;
-  if (dateTimeStr.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/)) {
+  // Date-only 'YYYY-MM-DD' must be expanded to a full local-midnight datetime
+  // first. Without this, new Date('2025-08-13') parses as UTC midnight while
+  // new Date('2025-08-13T08:00:00') parses as LOCAL — an inconsistency that
+  // contradicts the "bare timestamp -> local -> UTC" contract below.
+  // Example (host TZ = UTC+2): '2025-08-13' -> '2025-08-13T00:00:00' ->
+  // 2025-08-12T22:00:00Z (local midnight), not the old UTC-midnight result.
+  if (dateTimeStr.match(/^\d{4}-\d{2}-\d{2}$/)) {
+    normalizedStr = dateTimeStr + 'T00:00:00';
+  } else if (dateTimeStr.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/)) {
     // Add seconds if only HH:MM is provided
     normalizedStr = dateTimeStr + ':00';
   }
@@ -795,7 +803,7 @@ export class HistoryAPI {
     _tier: AggregationTier | undefined,
     _querySource: QuerySource,
     debug: (k: string) => void
-  ): Promise<Set<string>> {
+  ): Promise<Set<string> | null> {
     const timestamps = new Set<string>();
 
     // Build file path for raw position data
@@ -934,7 +942,10 @@ export class HistoryAPI {
       }
     } catch (error) {
       debug(`[Spatial Correlation] Error querying position data: ${error}`);
-      // On error, return empty set (no filtering will occur)
+      // A query error must not masquerade as "no positions in area". Return null
+      // so the caller skips correlation and leaves non-position paths unfiltered,
+      // rather than clearing them from a fabricated empty set.
+      return null;
     }
 
     return timestamps;
@@ -953,10 +964,20 @@ export class HistoryAPI {
     res: Response<any, Record<string, any>>
   ) {
     try {
-      // Resolution now in SECONDS (breaking change from v0.7.0)
+      // Auto-resolution targets ~500 buckets across the range, computed in
+      // millis and clamped to >=1ms. Mirrors the V2 provider guard so a
+      // zero-duration range (from==to) can't yield a 0ms bucket size, which the
+      // DuckDB FLOOR(EPOCH_MS / <size>) bucketing would otherwise turn into x/0.
+      const autoResolutionMillis = Math.max(
+        1,
+        Math.round(
+          (to.toInstant().toEpochMilli() - from.toInstant().toEpochMilli()) /
+            500
+        )
+      );
       const timeResolutionMillis = req.query.resolution
         ? parseResolutionToMillis(req.query.resolution as string)
-        : ((to.toEpochSecond() - from.toEpochSecond()) / 500) * 1000;
+        : autoResolutionMillis;
       // Strip everything except path/aggregate characters, the filter
       // delimiters from PATH_FILTER_DEFS, and `-` (common in source
       // references). This is a coarse injection guard; values are also SQL-
@@ -1142,7 +1163,7 @@ export class HistoryAPI {
           debug
         );
         debug(
-          `[Spatial Correlation] Found ${spatialTimestamps.size} valid timestamps`
+          `[Spatial Correlation] Found ${spatialTimestamps?.size ?? '(query error)'} valid timestamps`
         );
       }
 
@@ -1318,8 +1339,13 @@ export class HistoryAPI {
           }
         } catch (error) {
           debug(`[Spatial] Error in fast position query: ${error}`);
+          // A query error is NOT "no positions in area". Leaving an empty Set
+          // here would make the consumer below treat it as an authoritative
+          // empty result and silently clear every correlated non-position path.
+          // Null means "skip correlation": correlated paths are returned
+          // unfiltered, the safe outcome for a recoverable hiccup.
           allData[pathSpecKey(posPathSpec)] = [];
-          spatialTimestamps = new Set<string>();
+          spatialTimestamps = null;
         }
       }
     }

--- a/src/data-handler.ts
+++ b/src/data-handler.ts
@@ -660,15 +660,17 @@ function handleStreamData(
       const valueObj = normalizedDelta.value as Record<string, unknown>;
       const objKeys = Object.keys(valueObj);
 
-      // Skip if this looks like a meta-only update (only has units, meta, description keys)
-      // These are metadata updates, not actual data values
+      // Skip if this looks like a meta-only update — every key is a SignalK
+      // metadata field, so the object carries no real value to store. 'timeout'
+      // is intentionally NOT in this set: it can appear as a real value field,
+      // and the worst outcome here is silently dropping archived data, so we
+      // err toward keeping an object whose only key is 'timeout'.
       const metaOnlyKeys = [
         'units',
         'meta',
         'description',
         'displayUnits',
         'zones',
-        'timeout',
       ];
       const isMetaOnly =
         objKeys.length > 0 && objKeys.every(k => metaOnlyKeys.includes(k));

--- a/src/index.ts
+++ b/src/index.ts
@@ -213,12 +213,23 @@ export default function (app: ServerAPI): SignalKPlugin {
     // on disk; without this, every restart would re-trigger the
     // legacy detection. Also writes the corrected retentionDays = 0.
     if (needsLegacyRetentionMigration) {
-      app.savePluginOptions(state.currentConfig, (err?: unknown) => {
-        if (err) {
-          app.error(
-            `[Retention] Failed to persist legacy migration: ${(err as Error).message}`
-          );
-        }
+      // savePluginOptions is callback-based; await the promisified call so the
+      // configSchemaVersion sentinel is actually confirmed on disk within start
+      // ordering. Resolve even on error (a persistence hiccup must not block
+      // startup) but log loudly: the sentinel won't have landed, so the
+      // migration re-runs on the next restart.
+      await new Promise<void>(resolve => {
+        app.savePluginOptions(state.currentConfig!, (err?: unknown) => {
+          if (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            app.error(
+              `[Retention] Failed to persist legacy migration; the ` +
+                `configSchemaVersion stamp did not land and the migration will ` +
+                `re-run on next restart: ${msg}`
+            );
+          }
+          resolve();
+        });
       });
     }
 
@@ -1072,8 +1083,7 @@ export default function (app: ServerAPI): SignalKPlugin {
                   region: {
                     type: 'string',
                     title: 'AWS Region',
-                    description:
-                      'AWS region where the S3 bucket is located.',
+                    description: 'AWS region where the S3 bucket is located.',
                     default: 'us-east-1',
                   },
                   endpoint: {

--- a/src/services/aggregation-service.ts
+++ b/src/services/aggregation-service.ts
@@ -498,8 +498,15 @@ export class AggregationService {
       `;
     }
 
-    // Re-aggregate from already-aggregated data using stored sin/cos averages
-    // weighted by sample count for correct vector re-aggregation
+    // Re-aggregate from already-aggregated data using the stored sin/cos
+    // averages, weighted by sample_count. COALESCE falls back to deriving
+    // sin/cos from value_avg when an upstream tier predates the sin/cos columns,
+    // or metadata flapped so the angular columns are absent: without it a
+    // missing value_sin_avg/value_cos_avg makes the whole bucket NULL. This
+    // mirrors the query-time fallback in HistoryAPI's tier aggregation.
+    // Example: two source buckets at 10deg (0.1745 rad) and 350deg (6.1087 rad)
+    // with NULL sin/cos -> COALESCE uses SIN/COS(value_avg) ->
+    // ATAN2(~0, ~0.985) -> ~0 rad (0/360deg), not a 180deg arithmetic mean.
     return `
       COPY (
         SELECT
@@ -507,18 +514,18 @@ export class AggregationService {
           context,
           path,
           ATAN2(
-            SUM(value_sin_avg * sample_count) / SUM(sample_count),
-            SUM(value_cos_avg * sample_count) / SUM(sample_count)
+            SUM(COALESCE(value_sin_avg, SIN(value_avg)) * sample_count) / SUM(sample_count),
+            SUM(COALESCE(value_cos_avg, COS(value_avg)) * sample_count) / SUM(sample_count)
           ) as value_avg,
           NULL::DOUBLE as value_min,
           NULL::DOUBLE as value_max,
           SUM(sample_count)::BIGINT as sample_count,
-          SUM(value_sin_avg * sample_count) / SUM(sample_count) as value_sin_avg,
-          SUM(value_cos_avg * sample_count) / SUM(sample_count) as value_cos_avg,
+          SUM(COALESCE(value_sin_avg, SIN(value_avg)) * sample_count) / SUM(sample_count) as value_sin_avg,
+          SUM(COALESCE(value_cos_avg, COS(value_avg)) * sample_count) / SUM(sample_count) as value_cos_avg,
           MIN(first_timestamp) as first_timestamp,
           MAX(last_timestamp) as last_timestamp
         FROM (
-          SELECT bucket_time as src_bucket_time, context, path, value_sin_avg, value_cos_avg, sample_count, first_timestamp, last_timestamp
+          SELECT bucket_time as src_bucket_time, context, path, value_avg, value_sin_avg, value_cos_avg, sample_count, first_timestamp, last_timestamp
           FROM read_parquet([${fileListStr}], union_by_name=true)
         ) src
         GROUP BY time_bucket(INTERVAL '${intervalSeconds} seconds', src_bucket_time::TIMESTAMP), context, path

--- a/src/services/migration-service.ts
+++ b/src/services/migration-service.ts
@@ -36,6 +36,7 @@ export interface MigrationProgress {
   filesMigrated: number;
   filesSkipped: number;
   errors: string[];
+  cancelRequested?: boolean; // per-job cancel flag, set by cancel(jobId)
   aggregationDatesProcessed?: number;
   aggregationDatesTotal?: number;
   aggregationCurrentDate?: string;
@@ -64,7 +65,6 @@ function scheduleMigrationJobCleanup(jobId: string) {
 export class MigrationService {
   private readonly app: ServerAPI;
   private readonly hivePathBuilder: HivePathBuilder;
-  private cancelRequested: boolean = false;
 
   constructor(app: ServerAPI) {
     this.app = app;
@@ -164,7 +164,6 @@ export class MigrationService {
     };
 
     migrationJobs.set(jobId, progress);
-    this.cancelRequested = false;
 
     // Run migration in background
     this.runMigration(jobId, config).catch(error => {
@@ -230,7 +229,7 @@ export class MigrationService {
       progress.status = 'running';
 
       for (let i = 0; i < flatFiles.length; i++) {
-        if (this.cancelRequested) {
+        if (progress.cancelRequested) {
           progress.status = 'cancelled';
           progress.completedAt = new Date();
           scheduleMigrationJobCleanup(jobId);
@@ -288,7 +287,7 @@ export class MigrationService {
           progress.aggregationDatesProcessed = 0;
 
           for (let i = 0; i < dates.length; i++) {
-            if (this.cancelRequested) {
+            if (progress.cancelRequested) {
               progress.status = 'cancelled';
               progress.completedAt = new Date();
               scheduleMigrationJobCleanup(jobId);
@@ -440,8 +439,12 @@ export class MigrationService {
    */
   cancel(jobId: string): boolean {
     const job = migrationJobs.get(jobId);
-    if (job && job.status === 'running') {
-      this.cancelRequested = true;
+    // Accept 'scanning' as well as 'running': the scan phase runs before the
+    // migrate loop flips the status to 'running', and cancelRequested is checked
+    // inside that loop, so a cancel issued during scanning must take effect.
+    // Matches the cancel semantics in compaction and aggregation services.
+    if (job && (job.status === 'scanning' || job.status === 'running')) {
+      job.cancelRequested = true;
       return true;
     }
     return false;

--- a/tests/test-sqlite-buffer.js
+++ b/tests/test-sqlite-buffer.js
@@ -968,7 +968,7 @@ function flattenDeltaToRecord(context, skPath, timestamp, value, source, $source
   // Handle complex values — exact copy of data-handler.ts lines 528-568
   if (typeof value === 'object' && value !== null) {
     const objKeys = Object.keys(value);
-    const metaOnlyKeys = ['units', 'meta', 'description', 'displayUnits', 'zones', 'timeout'];
+    const metaOnlyKeys = ['units', 'meta', 'description', 'displayUnits', 'zones'];
     const isMetaOnly = objKeys.length > 0 && objKeys.every(k => metaOnlyKeys.includes(k));
     if (isMetaOnly) return null; // skip meta-only updates
 


### PR DESCRIPTION
Correctness fixes for the v1 release. Covered by build, lint, the full mocha suite (531 passing), and an adversarial review.

## What

- **Angular aggregation.** Add a `COALESCE(value_sin_avg, SIN(value_avg))` / `COALESCE(value_cos_avg, COS(value_avg))` fallback to the tier-to-tier angular re-aggregation so a missing or flapping sin/cos column yields a correct circular mean instead of NULL or an arithmetic mean of angles. Matches the query-time fallback already used by the History API; identical to the prior result when the columns are present.
- **Ingestion drop.** Stop discarding object deltas whose only key is `timeout`: it can be a real value field, so keeping it errs away from silent data loss.
- **Default resolution.** Clamp the v1 default resolution to >= 1 ms (computed in milliseconds, mirroring the v2 provider) so a zero-duration range can't produce a 0 ms DuckDB bucket size.
- **Datetime parsing.** Normalize date-only `YYYY-MM-DD` inputs to local midnight so bare timestamps are interpreted consistently with full datetimes.
- **Spatial correlation.** On a spatial position-query error, skip correlation (return null) instead of fabricating an empty set that silently empties every correlated path; a transient error no longer blanks unrelated data.
- **Migration.** Await the legacy-retention `savePluginOptions` so the `configSchemaVersion` stamp is confirmed before start proceeds; `cancel()` now accepts the `scanning` phase.

## Scope and merge order

One of four independent v1-stabilization PRs cut from `main`. Recommended merge order: security → reliability → correctness → hygiene (trial merge of all four was conflict-free).
