### PR TITLE
refactor: centralize job-id generation and route diagnostics through the logger

### DIFF
--- a/src/api-routes.ts
+++ b/src/api-routes.ts
@@ -64,6 +64,7 @@ import {
 } from './commands';
 import { updateDataSubscriptions } from './data-handler';
 import { toContextFilePath, toParquetFilePath } from './utils/path-helpers';
+import { newJobId } from './utils/job-id';
 import { ServerAPI, Context } from '@signalk/server-api';
 import { ClaudeAnalyzer, AnalysisRequest } from './claude-analyzer';
 import {
@@ -2964,7 +2965,7 @@ export function registerApiRoutes(
         ValidationApiResponse & { jobId: string; status?: string }
       >
     ) => {
-      const jobId = `val_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+      const jobId = newJobId('val');
       const progressJob: ValidationProgress = {
         jobId,
         status: 'running',
@@ -3462,7 +3463,7 @@ export function registerApiRoutes(
 
       targetFiles.sort((a, b) => a.relative.localeCompare(b.relative));
 
-      const jobId = `rep_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+      const jobId = newJobId('rep');
       const job: RepairProgress = {
         jobId,
         status: 'running',
@@ -4566,7 +4567,7 @@ export function registerApiRoutes(
       try {
         let session = uploadSessions.get(req);
         if (!session) {
-          const sessionId = `upload_${Date.now()}_${Math.random().toString(36).substring(2, 8)}`;
+          const sessionId = newJobId('upload');
           const dir = path.join(
             state.getDataDirPath(),
             'gpx-uploads',
@@ -5231,7 +5232,7 @@ export function registerApiRoutes(
   router.post('/api/migrate/vector-averaging', async (req, res) => {
     try {
       const { dryRun = false } = req.body || {};
-      const jobId = `vecavg_${Date.now()}_${Math.random().toString(36).substring(2, 8)}`;
+      const jobId = newJobId('vecavg');
 
       const job: {
         id: string;
@@ -5427,7 +5428,7 @@ export function registerApiRoutes(
   router.post('/api/migrate/position-aggregation', async (req, res) => {
     try {
       const { dryRun = false } = req.body || {};
-      const jobId = `posagg_${Date.now()}_${Math.random().toString(36).substring(2, 8)}`;
+      const jobId = newJobId('posagg');
 
       const job = {
         id: jobId,

--- a/src/claude-analyzer.ts
+++ b/src/claude-analyzer.ts
@@ -295,18 +295,18 @@ export class ClaudeAnalyzer {
       // Set resolution if provided (empty string = auto/let HistoryAPI choose)
       if (resolution && resolution.trim() !== '') {
         params.set('resolution', resolution);
-        console.log(
+        this.app?.debug(
           `📊 CLAUDE ANALYZER: Using custom resolution: ${resolution}ms`
         );
       } else {
-        console.log(
+        this.app?.debug(
           `📊 CLAUDE ANALYZER: Using auto resolution (HistoryAPI will choose optimal bucketing)`
         );
       }
 
       const url = `${baseUrl}/api/history/values?${params}`;
-      console.log(`🌐 CLAUDE ANALYZER: Making REST API call to ${url}`);
-      console.log(
+      this.app?.debug(`🌐 CLAUDE ANALYZER: Making REST API call to ${url}`);
+      this.app?.debug(
         `📊 CLAUDE ANALYZER: Using paths "${pathsWithAggregation}" ${aggregationMethod ? `with aggregation method "${aggregationMethod}"` : 'with default aggregation'}`
       );
 
@@ -317,8 +317,10 @@ export class ClaudeAnalyzer {
       }
 
       const apiResult = (await response.json()) as any;
-      console.log(
-        `📊 CLAUDE ANALYZER (REST API): Raw API result:`,
+      // Pass the value as a separate arg so app.debug only serializes it when
+      // the debug namespace is enabled (the debug module formats lazily).
+      this.app?.debug(
+        '📊 CLAUDE ANALYZER (REST API): Raw API result keys:',
         Object.keys(apiResult)
       );
 
@@ -332,10 +334,13 @@ export class ClaudeAnalyzer {
         apiResult.values &&
         Array.isArray(apiResult.values)
       ) {
-        console.log(
+        this.app?.debug(
           `🔍 CLAUDE ANALYZER: Processing ${apiResult.data.length} data rows with ${apiResult.values.length} value columns`
         );
-        console.log(`🔍 CLAUDE ANALYZER: Value column info:`, apiResult.values);
+        this.app?.debug(
+          '🔍 CLAUDE ANALYZER: Value column info:',
+          apiResult.values
+        );
 
         // Safety limit to prevent stack overflow
         const maxRows = Math.min(apiResult.data.length, 10000);
@@ -357,7 +362,7 @@ export class ClaudeAnalyzer {
               const valueInfo = apiResult.values[colIndex - 1]; // values array is 0-indexed
 
               if (rowIndex < 3) {
-                console.log(
+                this.app?.debug(
                   `🔍 Sample row ${rowIndex}, col ${colIndex}: timestamp=${timestamp}, path=${valueInfo?.path}, method=${valueInfo?.method}, value=${value}`
                 );
               }
@@ -376,12 +381,11 @@ export class ClaudeAnalyzer {
           }
         }
       } else {
-        console.log(`🔍 CLAUDE ANALYZER: No data array found in API result`);
+        this.app?.debug(
+          `🔍 CLAUDE ANALYZER: No data array found in API result`
+        );
       }
 
-      console.log(
-        `📊 CLAUDE ANALYZER (REST API): Loaded ${records.length} records for analysis from ${pathsWithAggregation}`
-      );
       this.app?.debug(
         `REST API loaded ${records.length} records for analysis from ${pathsWithAggregation}`
       );
@@ -1045,7 +1049,7 @@ Please structure your response as JSON with the following format:
       // Build time range guidance for Claude
       let timeRangeGuidance = '';
       if (request.timeRange) {
-        console.log(`🔍 REQUEST TIME RANGE DEBUG:`, {
+        this.app?.debug('🔍 REQUEST TIME RANGE DEBUG:', {
           userRequested: request.customPrompt || request.analysisType,
           actualStart: request.timeRange.start.toISOString(),
           actualEnd: request.timeRange.end.toISOString(),
@@ -3022,8 +3026,8 @@ Begin your analysis by querying relevant data within the specified time range.`;
 
         // Debug: Log the actual data structure and size
         const dataStr = JSON.stringify(currentData, null, 2);
-        console.log(`🔍 DATA SIZE: ${dataStr.length} characters`);
-        console.log(`🔍 DATA STRUCTURE:`, currentData);
+        this.app?.debug(`🔍 DATA SIZE: ${dataStr.length} characters`);
+        this.app?.debug('🔍 DATA STRUCTURE:', dataStr);
 
         const resultSummary = `Current SignalK data "${purpose}":\n\n${dataStr}`;
 

--- a/src/utils/job-id.ts
+++ b/src/utils/job-id.ts
@@ -1,0 +1,17 @@
+/**
+ * Generates a unique identifier for a background job.
+ *
+ * WHY a shared helper: job-id construction was duplicated across many routes
+ * with inconsistent randomness (the deprecated String.prototype.substr vs
+ * substring, and differing suffix lengths). Centralizing it guarantees one
+ * format and removes the deprecated call.
+ *
+ * Format: `${prefix}_${epochMillis}_${base36-random}`. The timestamp keeps ids
+ * roughly sortable; the random suffix avoids collisions within the same
+ * millisecond.
+ *
+ * Input:  newJobId('val')  ->  "val_1718900000000_k3f9a1b2c"
+ */
+export function newJobId(prefix: string): string {
+  return `${prefix}_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
+}

--- a/test/unit/utils/job-id.test.ts
+++ b/test/unit/utils/job-id.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Unit tests for the shared background-job id helper.
+ */
+import { expect } from 'chai';
+import { newJobId } from '../../../src/utils/job-id';
+
+describe('newJobId', () => {
+  it('prefixes the id with the given prefix', () => {
+    expect(newJobId('val')).to.match(/^val_/);
+    expect(newJobId('posagg')).to.match(/^posagg_/);
+  });
+
+  it('produces the prefix_millis_random shape', () => {
+    expect(newJobId('rep')).to.match(/^rep_\d+_[a-z0-9]+$/);
+  });
+
+  it('produces distinct ids on successive calls', () => {
+    const ids = new Set(Array.from({ length: 100 }, () => newJobId('x')));
+    expect(ids.size).to.equal(100);
+  });
+});


### PR DESCRIPTION
Small hygiene cleanups for the v1 release. Covered by build, lint, and the full mocha suite (534 passing, including a new unit test).

## What

- **Job IDs.** Add a single `newJobId(prefix)` helper and use it for the five background-job IDs in `api-routes` (removing the deprecated `String.prototype.substr` and the inconsistent suffix lengths; prefixes preserved).
- **Diagnostics.** Route `claude-analyzer`'s `console.log` diagnostics through `app.debug` so they respect the Signal K debug toggle instead of writing straight to stdout.

The `package.json` `test` script flagged during review already runs mocha, so no change was needed there.

## Scope and merge order

One of four independent v1-stabilization PRs cut from `main`. Recommended merge order: security → reliability → correctness → hygiene (trial merge of all four was conflict-free).
