### PR TITLE
fix: prevent DuckDB from opening the live SQLite write buffer

### DIFF
--- a/src/api-routes.ts
+++ b/src/api-routes.ts
@@ -5,6 +5,7 @@ import express, { Router } from 'express';
 import multer from 'multer';
 import { getAvailablePaths } from './utils/path-discovery';
 import { DuckDBPool } from './utils/duckdb-pool';
+import { findUnsafeSqlReason } from './utils/sql-guard';
 import {
   TypedRequest,
   TypedResponse,
@@ -119,6 +120,12 @@ interface RepairProgress {
 const repairJobs = new Map<string, RepairProgress>();
 
 const VALIDATION_JOB_TTL_MS = 10 * 60 * 1000; // Retain job metadata for 10 minutes
+
+/**
+ * Row cap for the raw SQL endpoint. Results are materialised into the Node
+ * heap before serialisation, which DuckDB's own memory limit does not bound.
+ */
+const RAW_QUERY_MAX_ROWS = 10000;
 
 function scheduleValidationJobCleanup(jobId: string) {
   setTimeout(() => {
@@ -500,8 +507,29 @@ export function registerApiRoutes(
                 selfContextPath,
                 quotedPath
               );
-              processedQuery = processedQuery.replace(match, `'${filePath}'`);
+              // Replacer function, not a string: `$&` and `` $` `` in a
+              // user-supplied path would otherwise be expanded by replace()
+              // and splice unvalidated text into the executed SQL.
+              processedQuery = processedQuery.replace(
+                match,
+                () => `'${filePath}'`
+              );
             }
+          });
+        }
+
+        // Validate the string that actually executes, after substitution, so
+        // the guarded SQL and the executed SQL cannot diverge. Statements like
+        // ATTACH or "sqlite_scan"() would open the live SQLite buffer with
+        // DuckDB's bundled SQLite and crash the server (see sql-guard.ts).
+        const unsafeReason = findUnsafeSqlReason(processedQuery);
+        if (unsafeReason) {
+          app.debug(
+            `Rejected raw SQL query: ${unsafeReason} — query: ${processedQuery.slice(0, 200)}`
+          );
+          return res.status(400).json({
+            success: false,
+            error: unsafeReason,
           });
         }
 
@@ -512,12 +540,19 @@ export function registerApiRoutes(
           const reader = await connection.runAndReadAll(processedQuery);
           const rawData = reader.getRowObjects();
 
-          const data = mapForJSON(rawData);
+          // Cap before mapping: the whole result set is materialised into the
+          // Node heap, which DuckDB's own memory limit does not bound, and a
+          // SELECT * over a year of parquet would OOM the SignalK process.
+          const truncated = rawData.length > RAW_QUERY_MAX_ROWS;
+          const data = mapForJSON(
+            truncated ? rawData.slice(0, RAW_QUERY_MAX_ROWS) : rawData
+          );
 
           return res.json({
             success: true,
             query: processedQuery,
             rowCount: data.length,
+            truncated,
             data: data,
           });
         } catch (err) {

--- a/src/claude-analyzer.ts
+++ b/src/claude-analyzer.ts
@@ -12,6 +12,7 @@ import { getAvailablePaths } from './utils/path-discovery';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { DuckDBPool } from './utils/duckdb-pool';
+import { findUnsafeSqlReason } from './utils/sql-guard';
 import { ClaudeModel } from './claude-models';
 import { shouldSkipDirectory } from './utils/path-helpers';
 
@@ -3345,26 +3346,16 @@ Begin your analysis by querying relevant data within the specified time range.`;
     // Auto-correct common column usage patterns
     const correctedSQL = this.correctColumnUsage(sql);
 
-    // Validate query is read-only (starts with SELECT or WITH for CTEs)
-    const trimmedSQL = correctedSQL.trim().toUpperCase();
-    if (!trimmedSQL.startsWith('SELECT') && !trimmedSQL.startsWith('WITH')) {
-      throw new Error('Only SELECT and WITH queries are allowed for security');
-    }
-
-    // Additional safety checks
-    const dangerousKeywords = [
-      'DROP',
-      'DELETE',
-      'UPDATE',
-      'INSERT',
-      'CREATE',
-      'ALTER',
-      'TRUNCATE',
-    ];
-    for (const keyword of dangerousKeywords) {
-      if (trimmedSQL.includes(keyword)) {
-        throw new Error(`Dangerous SQL keyword '${keyword}' is not allowed`);
-      }
+    // Validate every statement is read-only and touches no database- or
+    // file-opening table function. The reason is thrown back to the model as a
+    // tool result so it can rewrite the query; log it too, since a model
+    // looping on rejected SQL is otherwise invisible from the server side.
+    const unsafeReason = findUnsafeSqlReason(correctedSQL);
+    if (unsafeReason) {
+      this.app?.debug(
+        `Rejected AI-generated SQL for ${purpose}: ${unsafeReason} — query: ${correctedSQL.slice(0, 200)}`
+      );
+      throw new Error(`Query rejected for security: ${unsafeReason}`);
     }
 
     // Use shared pool - spatial extension is already loaded at startup

--- a/src/index.ts
+++ b/src/index.ts
@@ -336,7 +336,10 @@ export default function (app: ServerAPI): SignalKPlugin {
     await DuckDBPool.initialize(state.currentConfig.outputDirectory, msg =>
       app.error(msg)
     );
-    app.debug('DuckDB connection pool initialized');
+    app.debug(
+      `DuckDB connection pool initialized (sqlite lockdown: ` +
+        `${DuckDBPool.getLockdownSummary()})`
+    );
 
     // Register SQLite buffer path with DuckDB for federated queries
     if (state.sqliteBuffer) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -370,6 +370,8 @@ export interface FilesApiResponse extends ApiResponse {
 export interface QueryApiResponse extends ApiResponse {
   query?: string;
   rowCount?: number;
+  /** True when the result set was cut off at the row cap. */
+  truncated?: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data?: any[];
 }

--- a/src/utils/duckdb-pool.ts
+++ b/src/utils/duckdb-pool.ts
@@ -40,6 +40,9 @@ export class DuckDBPool {
   private static sqliteDbPath: string | null = null;
   private static sqliteInitialized: boolean = false;
   private static spatialAvailable: boolean = false;
+  private static sqliteAutoloadDisabled: boolean = false;
+  private static sqliteExtensionRemoved: boolean = false;
+  private static lockdownSummary: string = 'not applied';
 
   /**
    * Initialize the DuckDB instance and load extensions
@@ -104,11 +107,140 @@ export class DuckDBPool {
         );
       }
 
+      await this.lockDownSqliteExtension(setupConn, homeBaseDir, warn);
+
       this.instance = instance;
       this.initialized = true;
     } finally {
       setupConn.disconnectSync();
     }
+  }
+
+  /**
+   * Raise the cost of DuckDB's bundled SQLite ever opening the live write
+   * buffer: doing so truncates buffer.db-shm under node:sqlite's active mmap
+   * and kills the server with SIGBUS (see buffer-staging.ts).
+   *
+   * What each measure actually buys, since the boundaries are easy to
+   * overestimate:
+   * - Removing a cached sqlite_scanner is what stops `ATTACH ... (TYPE
+   *   SQLITE)`. A cached extension loads on ATTACH regardless of the autoload
+   *   setting, and every installation that ran the old federation code has one
+   *   cached here.
+   * - Disabling autoinstall/autoload stops SQL that merely references
+   *   sqlite_scan() from pulling the extension in, and stops a re-download.
+   * - Locking the configuration stops a later query flipping those toggles
+   *   back on. Explicit INSTALL/LOAD (spatial above, httpfs in initializeS3)
+   *   and CREATE SECRET still work once the config is locked.
+   *
+   * These do NOT stop an explicit `INSTALL sqlite; LOAD sqlite;`, which
+   * re-populates the cache and makes sqlite_scan() live again. Only the SQL
+   * guard's read-only statement whitelist rejects that, so the two layers are
+   * complementary rather than redundant: the guard blocks the statements, this
+   * blocks the implicit loads the guard's function check might miss.
+   *
+   * Hardening failures must not take down the plugin — parquet writing and the
+   * history API matter more. isSqliteLockedDown() reports the outcome so the
+   * degraded state is visible rather than assumed.
+   */
+  private static async lockDownSqliteExtension(
+    setupConn: Awaited<ReturnType<DuckDBInstance['connect']>>,
+    homeBaseDir: string | undefined,
+    warn?: (message: string) => void
+  ): Promise<void> {
+    let cachedExtensionsRemoved = 0;
+
+    if (homeBaseDir) {
+      const extensionDir = path.join(homeBaseDir, '.duckdb', 'extensions');
+      try {
+        const entries: string[] = (await fs.pathExists(extensionDir))
+          ? await fs.readdir(extensionDir, {
+              recursive: true,
+              encoding: 'utf8',
+            })
+          : [];
+        for (const entry of entries) {
+          if (path.basename(entry).startsWith('sqlite_scanner')) {
+            await fs.remove(path.join(extensionDir, entry));
+            cachedExtensionsRemoved += 1;
+          }
+        }
+        this.sqliteExtensionRemoved = true;
+      } catch (err) {
+        warn?.(
+          `Could not remove a cached DuckDB sqlite extension from ` +
+            `${extensionDir}: ${(err as Error).message}. Raw SQL and ` +
+            `AI-generated queries remain guarded, but avoid enabling raw SQL ` +
+            `until the file is gone.`
+        );
+      }
+    } else {
+      // No plugin-owned extension directory: DuckDB uses its default home and
+      // there is nothing here that we own well enough to delete.
+      this.sqliteExtensionRemoved = true;
+    }
+
+    // Applied one at a time: a failure on the first (e.g. a future DuckDB
+    // renaming the option) must not skip the other two.
+    const settings: [string, string][] = [
+      ['autoinstall_known_extensions', 'false'],
+      ['autoload_known_extensions', 'false'],
+      // Must come last — it freezes every option above.
+      ['lock_configuration', 'true'],
+    ];
+    const failed: string[] = [];
+    for (const [name, value] of settings) {
+      try {
+        await setupConn.runAndReadAll(`SET GLOBAL ${name} = ${value};`);
+      } catch (err) {
+        failed.push(`${name} (${(err as Error).message})`);
+      }
+    }
+
+    // Read back rather than trusting the SET calls, so a silently ineffective
+    // option is reported as unlocked instead of assumed applied.
+    let verified = false;
+    try {
+      const reader = await setupConn.runAndReadAll(
+        `SELECT value FROM duckdb_settings() ` +
+          `WHERE name = 'autoload_known_extensions';`
+      );
+      const rows = reader.getRowObjects();
+      verified = String(rows[0]?.value).toLowerCase() === 'false';
+    } catch (err) {
+      failed.push(`read-back (${(err as Error).message})`);
+    }
+
+    this.sqliteAutoloadDisabled = verified;
+
+    if (failed.length > 0 || !verified) {
+      warn?.(
+        `Could not fully lock down DuckDB extension loading ` +
+          `(${failed.join('; ') || 'settings did not take effect'}). The SQL ` +
+          `guard still rejects the statements that could open the write ` +
+          `buffer, but avoid enabling raw SQL on this instance.`
+      );
+    }
+
+    this.lockdownSummary =
+      `removed ${cachedExtensionsRemoved} cached sqlite extension file(s), ` +
+      `autoload disabled: ${verified}`;
+  }
+
+  /**
+   * Whether the SQLite extension lockdown fully applied. False means DuckDB
+   * could still load its sqlite extension on this instance, so raw SQL should
+   * be treated as unsafe even though the SQL guard remains in force.
+   */
+  static isSqliteLockedDown(): boolean {
+    return this.sqliteAutoloadDisabled && this.sqliteExtensionRemoved;
+  }
+
+  /**
+   * One-line description of what the lockdown did, for startup logging.
+   */
+  static getLockdownSummary(): string {
+    return this.lockdownSummary;
   }
 
   /**
@@ -159,16 +291,27 @@ export class DuckDBPool {
 
   /**
    * Cleanup on plugin shutdown
-   * Sets the instance to null to allow garbage collection
+   *
+   * Closes the native instance rather than waiting for a finalizer: a plugin
+   * disable/enable cycle would otherwise leave the previous DuckDB instance
+   * (and its own memory budget) alive on hardware that has little to spare.
    */
   static async shutdown(): Promise<void> {
     if (this.instance) {
-      // DuckDB instances handle cleanup automatically
+      try {
+        this.instance.closeSync();
+      } catch {
+        // Close is best-effort; dropping the reference still allows GC and a
+        // failure here must not break plugin.stop().
+      }
       this.instance = null;
       this.initialized = false;
       this.s3Initialized = false;
       this.sqliteDbPath = null;
       this.sqliteInitialized = false;
+      this.sqliteAutoloadDisabled = false;
+      this.sqliteExtensionRemoved = false;
+      this.lockdownSummary = 'not applied';
     }
   }
 

--- a/src/utils/sql-guard.ts
+++ b/src/utils/sql-guard.ts
@@ -1,0 +1,207 @@
+/**
+ * Validation for user- and model-supplied SQL executed on the shared DuckDB
+ * pool (the raw /api/query endpoint and Claude-generated analysis queries).
+ *
+ * DuckDB must never open the live SQLite buffer (see buffer-staging.ts): its
+ * bundled SQLite cannot see node:sqlite's in-process POSIX locks, so it treats
+ * the database as unused, runs WAL recovery, and truncates the -shm file under
+ * the writer's active mmap, killing the server with SIGBUS.
+ *
+ * Two rules, because the dangerous constructs arrive in two shapes:
+ *
+ * 1. Every statement must be a read-only query. ATTACH, INSTALL and LOAD reach
+ *    the SQLite code path directly; COPY and EXPORT DATABASE write files; SET
+ *    and PRAGMA can undo the engine lockdown in duckdb-pool. A whitelist
+ *    rejects all of them, plus the next spelling of the same capability, and
+ *    plus anything chained after a benign leading SELECT. Blocklists were tried
+ *    first and lost to CALL sqlite_attach(...), FORCE INSTALL and EXPORT
+ *    DATABASE.
+ *
+ * 2. Some table functions open databases or files from inside an otherwise
+ *    valid SELECT, so they are rejected by name: the sqlite_* family, query()
+ *    and query_table() (which execute a nested SQL string that rule 1 cannot
+ *    see), and the raw file readers read_text/read_blob/glob.
+ *
+ * The name check deliberately runs over SQL whose quoted identifiers are still
+ * visible. DuckDB resolves "sqlite_scan"('db','t') exactly like the bare form,
+ * so masking identifiers before this check let the quoted spelling through.
+ *
+ * Scope note: this is not a filesystem sandbox. read_parquet and read_csv can
+ * still read any path the process can reach — that is inherent to an endpoint
+ * whose purpose is running SQL over local files, and it predates this guard.
+ * What is guaranteed here is only that DuckDB never opens the write buffer as
+ * a database and never writes through the query engine.
+ */
+
+/**
+ * Statement kinds that only read. DuckDB's FROM-first form (`FROM t SELECT *`),
+ * DESCRIBE/SUMMARIZE/EXPLAIN and a parenthesised leading subquery are all
+ * idiomatic read-only SQL that the raw query console is expected to accept.
+ */
+const READ_ONLY_STATEMENT_START =
+  /^(SELECT|WITH|FROM|DESCRIBE|SUMMARIZE|EXPLAIN|VALUES|PIVOT|UNPIVOT|TABLE|SHOW|\()/i;
+
+/**
+ * Statement kinds worth naming explicitly in the rejection message, because
+ * they are the ones a caller might reasonably expect to work.
+ */
+const FILE_OR_STATE_STATEMENTS = [
+  'ATTACH',
+  'DETACH',
+  'INSTALL',
+  'FORCE',
+  'LOAD',
+  'COPY',
+  'EXPORT',
+  'IMPORT',
+  'SET',
+  'RESET',
+  'PRAGMA',
+  'CALL',
+];
+
+/**
+ * Table functions that open a database or a raw file, or execute a nested SQL
+ * string the statement whitelist cannot inspect. `sqlite_\w+` covers scan,
+ * attach and query without needing to track additions to the extension.
+ */
+const FORBIDDEN_FUNCTION_PATTERN =
+  /\b(sqlite_\w+|query|query_table|read_text|read_blob|glob|duckdb_secrets)\s*\(/i;
+
+/**
+ * Statement keywords that can never appear in a read-only query. The statement
+ * whitelist rejects them at statement start; scanning anywhere as well catches
+ * the WITH-prefixed form, e.g.
+ * `WITH x AS (SELECT 3 AS a) INSERT INTO t SELECT a FROM x`, which DuckDB
+ * parses and runs and which starts with an allowed keyword.
+ */
+const DATA_MODIFYING_KEYWORDS = [
+  'DROP',
+  'DELETE',
+  'UPDATE',
+  'INSERT',
+  'CREATE',
+  'ALTER',
+  'TRUNCATE',
+];
+
+/** Blank every character of a match except newlines, preserving offsets. */
+function blank(match: string): string {
+  return match.replace(/[^\r\n]/g, ' ');
+}
+
+const STRINGS_AND_COMMENTS =
+  /'(?:[^']|'')*'?|\$(\w*)\$[\s\S]*?(?:\$\1\$|$)|--[^\r\n]*|\/\*[\s\S]*?(?:\*\/|$)/g;
+const QUOTED_IDENTIFIER = /"(?:[^"]|"")*"?/g;
+
+/**
+ * Blank SQL string literals ('...' with '' escapes), dollar-quoted strings
+ * ($$...$$, $tag$...$tag$), quoted identifiers ("..."), and comments (-- line,
+ * block) so statement splitting and keyword scanning never see content DuckDB
+ * treats as data. Replacement preserves length and newlines so offsets and
+ * line numbers still line up.
+ *
+ * Input:  SELECT 'a;b' AS x -- attach note
+ * Output: SELECT       AS x
+ *
+ * An unterminated literal or comment is blanked to the end of the input.
+ * DuckDB rejects every such form at parse time ("unterminated quoted string",
+ * "unterminated /* comment", and the same for quoted identifiers and
+ * dollar-quoted strings), so nothing executable can hide behind one.
+ */
+export function maskSqlLiteralsAndComments(sql: string): string {
+  return sql
+    .replace(STRINGS_AND_COMMENTS, blank)
+    .replace(QUOTED_IDENTIFIER, blank);
+}
+
+/**
+ * Mask for the function-name check: blanks strings and comments but keeps
+ * quoted identifiers, then removes the quote characters so that
+ * `"sqlite_scan"(` collapses to `sqlite_scan(` and matches.
+ *
+ * A quoted alias that literally contains a forbidden name followed by `(`
+ * becomes a false positive. That trade is deliberate — the alternative let the
+ * quoted spelling reach the live buffer.
+ */
+function maskForFunctionScan(sql: string): string {
+  return sql.replace(STRINGS_AND_COMMENTS, blank).replace(/"/g, '');
+}
+
+/**
+ * Find the first whole-word occurrence of any keyword outside literals and
+ * comments. Keywords are module-private constants consisting of word
+ * characters, so no escaping is needed.
+ */
+function findSqlKeyword(
+  maskedSql: string,
+  keywords: readonly string[]
+): string | null {
+  for (const keyword of keywords) {
+    if (new RegExp(`\\b${keyword}\\b`, 'i').test(maskedSql)) {
+      return keyword;
+    }
+  }
+  return null;
+}
+
+/**
+ * Split masked SQL into statements on semicolons. Semicolons inside literals
+ * and comments are already blanked, so a plain split is safe.
+ */
+function splitStatements(maskedSql: string): string[] {
+  return maskedSql
+    .split(';')
+    .map(statement => statement.trim())
+    .filter(statement => statement.length > 0);
+}
+
+/**
+ * Check user- or model-supplied SQL for anything that is not a plain read-only
+ * query. Returns a human-readable rejection reason (surfaced to the API caller
+ * and fed back to the model so it can retry), or null when the SQL is safe to
+ * execute.
+ */
+export function findUnsafeSqlReason(sql: string): string | null {
+  const masked = maskSqlLiteralsAndComments(sql);
+  const statements = splitStatements(masked);
+
+  if (statements.length === 0) {
+    return 'Query is empty.';
+  }
+
+  for (const statement of statements) {
+    if (!READ_ONLY_STATEMENT_START.test(statement)) {
+      const firstWord = statement.split(/\s+/)[0].toUpperCase();
+      if (FILE_OR_STATE_STATEMENTS.includes(firstWord)) {
+        return (
+          `'${firstWord}' is not allowed: it can open a database file, write ` +
+          `to the filesystem, or change engine settings. Only read-only ` +
+          `queries are permitted.`
+        );
+      }
+      return (
+        `Only read-only queries are allowed (SELECT, WITH, FROM, DESCRIBE, ` +
+        `SUMMARIZE, EXPLAIN, VALUES, PIVOT, TABLE, SHOW); got '${firstWord}'.`
+      );
+    }
+  }
+
+  const forbiddenFunction = FORBIDDEN_FUNCTION_PATTERN.exec(
+    maskForFunctionScan(sql)
+  );
+  if (forbiddenFunction) {
+    return (
+      `Table function '${forbiddenFunction[1]}' is not allowed: it opens a ` +
+      `database or file directly, or runs nested SQL that cannot be checked. ` +
+      `Use read_parquet for data files.`
+    );
+  }
+
+  const modifying = findSqlKeyword(masked, DATA_MODIFYING_KEYWORDS);
+  if (modifying) {
+    return `Data-modifying keyword '${modifying}' is not allowed.`;
+  }
+
+  return null;
+}

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -22,6 +22,7 @@
     "src/utils/path-filters.ts",
     "src/utils/path-helpers.ts",
     "src/utils/retention-rules.ts",
+    "src/utils/sql-guard.ts",
     "src/utils/spatial-queries.ts",
     "src/utils/sql-escape.ts",
     "src/utils/type-detector.ts",

--- a/test/integration/duckdb-sqlite-lockdown.test.ts
+++ b/test/integration/duckdb-sqlite-lockdown.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Pins the DuckDB-side half of the buffer isolation defence.
+ *
+ * DuckDB's bundled SQLite opening the live write buffer truncates
+ * buffer.db-shm under node:sqlite's active mmap and kills the server with
+ * SIGBUS (see src/utils/buffer-staging.ts). DuckDBPool.initialize() therefore
+ * removes any cached sqlite extension, disables extension autoloading, and
+ * locks the configuration so a query cannot switch it back on.
+ *
+ * The removal step is the one that actually stops `ATTACH ... (TYPE SQLITE)`:
+ * a cached extension loads on ATTACH regardless of the autoload setting, and
+ * every installation that ran the old federation code has one cached. That
+ * step never executed in CI before this suite, because the other integration
+ * suites call initialize() with no home directory.
+ *
+ * DuckDBPool is a static singleton shared with the other suites, so the pool
+ * is shut down before and after each case to keep this order-independent.
+ */
+import { expect } from 'chai';
+import * as fs from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
+import { DuckDBPool } from '../../src/utils/duckdb-pool';
+
+/** Where DuckDB caches downloaded extensions under a plugin home directory. */
+const CACHED_EXTENSION = path.join(
+  '.duckdb',
+  'extensions',
+  'v1.5.3',
+  'test_platform',
+  'sqlite_scanner.duckdb_extension'
+);
+
+describe('DuckDB SQLite extension lockdown', function () {
+  this.timeout(30000);
+
+  let homeDir: string;
+  let warnings: string[];
+
+  beforeEach(async () => {
+    await DuckDBPool.shutdown();
+    homeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'duckdb-lockdown-'));
+    warnings = [];
+  });
+
+  afterEach(async () => {
+    await DuckDBPool.shutdown();
+    try {
+      await fs.remove(homeDir);
+    } catch {
+      // Windows keeps a loaded extension DLL mapped for the life of the
+      // process, so the temp directory may not be removable here. It is under
+      // the OS temp dir; leaving it must not fail the suite.
+    }
+  });
+
+  const initialize = () =>
+    DuckDBPool.initialize(homeDir, message => warnings.push(message));
+
+  /** Warnings unrelated to the lockdown (e.g. offline spatial download). */
+  const lockdownWarnings = () =>
+    warnings.filter(w => /lock down|cached DuckDB sqlite/i.test(w));
+
+  it('removes a cached sqlite extension', async () => {
+    const cached = path.join(homeDir, CACHED_EXTENSION);
+    await fs.outputFile(cached, 'not a real extension');
+
+    await initialize();
+
+    expect(await fs.pathExists(cached)).to.equal(false);
+    expect(DuckDBPool.getLockdownSummary()).to.include(
+      'removed 1 cached sqlite extension file(s)'
+    );
+    expect(lockdownWarnings()).to.deep.equal([]);
+  });
+
+  it('reports the lockdown as applied', async () => {
+    await initialize();
+
+    expect(DuckDBPool.isSqliteLockedDown()).to.equal(true);
+    expect(DuckDBPool.getLockdownSummary()).to.include(
+      'autoload disabled: true'
+    );
+  });
+
+  it('leaves extension autoloading disabled', async () => {
+    await initialize();
+
+    const connection = await DuckDBPool.getConnection();
+    try {
+      const reader = await connection.runAndReadAll(
+        `SELECT value FROM duckdb_settings() ` +
+          `WHERE name = 'autoload_known_extensions'`
+      );
+      expect(String(reader.getRowObjects()[0].value).toLowerCase()).to.equal(
+        'false'
+      );
+    } finally {
+      connection.disconnectSync();
+    }
+  });
+
+  it('refuses to re-enable autoloading from a query', async () => {
+    await initialize();
+
+    const connection = await DuckDBPool.getConnection();
+    try {
+      let message = '';
+      try {
+        await connection.runAndReadAll(
+          'SET GLOBAL autoload_known_extensions = true;'
+        );
+      } catch (err) {
+        message = (err as Error).message;
+      }
+      expect(message).to.match(/configuration has been locked/);
+    } finally {
+      connection.disconnectSync();
+    }
+  });
+
+  it('cannot ATTACH a SQLite database once the cache is cleared', async () => {
+    await fs.outputFile(path.join(homeDir, CACHED_EXTENSION), 'stale');
+    await initialize();
+
+    const connection = await DuckDBPool.getConnection();
+    try {
+      const target = path.join(homeDir, 'buffer.db').replace(/\\/g, '/');
+      let message = '';
+      try {
+        await connection.runAndReadAll(
+          `ATTACH '${target}' AS b (TYPE SQLITE, READ_ONLY);`
+        );
+      } catch (err) {
+        message = (err as Error).message;
+      }
+      // Fails at extension load, before any file is opened — which is the
+      // whole point: no SQLite library touches the buffer.
+      expect(message).to.match(/sqlite_scanner|not found|autoload/i);
+    } finally {
+      connection.disconnectSync();
+    }
+  });
+
+  it('applies the lockdown when no home directory is configured', async () => {
+    await DuckDBPool.initialize(undefined, message => warnings.push(message));
+
+    expect(DuckDBPool.isSqliteLockedDown()).to.equal(true);
+    expect(lockdownWarnings()).to.deep.equal([]);
+  });
+});

--- a/test/integration/raw-sql-guard-http.test.ts
+++ b/test/integration/raw-sql-guard-http.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Pins that the raw SQL endpoint is actually guarded.
+ *
+ * The SQL guard itself is unit-tested; what this covers is the wiring. Without
+ * it, deleting the guard call from the /api/query handler leaves the whole
+ * suite green while re-opening the path that lets DuckDB's bundled SQLite open
+ * the live write buffer and kill the server with SIGBUS (see buffer-staging).
+ *
+ * The real handler is obtained by running the plugin's own route registration
+ * against a recording router, rather than by mounting an Express app: several
+ * unrelated routes in this module use Express 4 path syntax that the Express 5
+ * in devDependencies refuses to parse, and the Signal K server supplies the
+ * router in production. Invoking the captured handler keeps the test on the
+ * real code path while sidestepping route parsing entirely.
+ *
+ * The guard returns before any DuckDB connection is taken, so no pool or
+ * fixture data is needed.
+ */
+import { expect } from 'chai';
+import { Router } from 'express';
+import { registerApiRoutes } from '../../src/api-routes';
+import { PluginState } from '../../src/types';
+import { createFakeSignalK, FakeSignalK } from './helpers/fake-signalk';
+
+const SELF_ID = 'rawsqlself';
+
+type Handler = (req: unknown, res: unknown) => Promise<void> | void;
+
+interface CapturedResponse {
+  status: number;
+  body: { success?: boolean; error?: string };
+}
+
+/** Minimal router double recording the handlers the plugin registers. */
+function createRecordingRouter(): {
+  router: Router;
+  posts: Map<string, Handler>;
+} {
+  const posts = new Map<string, Handler>();
+  const noop = () => router;
+  const router = {
+    use: noop,
+    get: noop,
+    put: noop,
+    delete: noop,
+    patch: noop,
+    post: (routePath: string, ...handlers: Handler[]) => {
+      // Some routes take middleware first; the last argument is the handler.
+      posts.set(routePath, handlers[handlers.length - 1]);
+      return router;
+    },
+  } as unknown as Router;
+  return { router, posts };
+}
+
+/** Express-shaped response double capturing status and JSON body. */
+function createResponse(): {
+  res: unknown;
+  captured: () => CapturedResponse;
+} {
+  let status = 200;
+  let body: CapturedResponse['body'] = {};
+  const res = {
+    status(code: number) {
+      status = code;
+      return res;
+    },
+    json(payload: CapturedResponse['body']) {
+      body = payload;
+      return res;
+    },
+  };
+  return { res, captured: () => ({ status, body }) };
+}
+
+describe('raw SQL endpoint guard', function () {
+  this.timeout(30000);
+
+  let host: FakeSignalK;
+  let handler: Handler;
+  let enableRawSql: boolean;
+
+  const queryApp = {
+    debug: () => {},
+    error: () => {},
+    getMetadata: () => undefined,
+    getSelfPath: () => undefined,
+    selfId: SELF_ID,
+    selfContext: `vessels.${SELF_ID}`,
+  };
+
+  async function postQuery(query: string): Promise<CapturedResponse> {
+    const { res, captured } = createResponse();
+    await handler({ body: { query }, params: {}, query: {} }, res);
+    return captured();
+  }
+
+  beforeEach(() => {
+    host = createFakeSignalK({ selfId: SELF_ID });
+    enableRawSql = true;
+
+    // Only the slice of PluginState the /api/query handler reads.
+    const state = {
+      getDataDirPath: () => host.dataDir,
+      get currentConfig() {
+        return { enableRawSql, outputDirectory: host.dataDir };
+      },
+    } as unknown as PluginState;
+
+    const { router, posts } = createRecordingRouter();
+    registerApiRoutes(router, state, queryApp as never);
+
+    const captured = posts.get('/api/query');
+    expect(captured, 'the plugin registers a POST /api/query route').to.be.a(
+      'function'
+    );
+    handler = captured as Handler;
+  });
+
+  afterEach(async () => {
+    await host?.cleanup();
+  });
+
+  it('rejects ATTACH of a SQLite database with 400', async () => {
+    const { status, body } = await postQuery(
+      "ATTACH '/tmp/buffer.db' AS b (TYPE SQLITE)"
+    );
+    expect(status).to.equal(400);
+    expect(body.success).to.equal(false);
+    expect(body.error).to.match(/'ATTACH' is not allowed/);
+  });
+
+  it('rejects a quoted-identifier sqlite_scan with 400', async () => {
+    const { status, body } = await postQuery(
+      `SELECT v FROM "sqlite_scan"('/tmp/buffer.db','t')`
+    );
+    expect(status).to.equal(400);
+    expect(body.error).to.match(/Table function/);
+  });
+
+  it('rejects a statement chained after a benign SELECT with 400', async () => {
+    const { status, body } = await postQuery(
+      'SELECT 1; SET GLOBAL autoload_known_extensions = true'
+    );
+    expect(status).to.equal(400);
+    expect(body.error).to.match(/'SET' is not allowed/);
+  });
+
+  it('returns 403 before the guard when raw SQL is disabled', async () => {
+    enableRawSql = false;
+    const { status, body } = await postQuery("ATTACH '/tmp/buffer.db' AS b");
+    expect(status).to.equal(403);
+    expect(body.error).to.match(/Raw SQL queries are disabled/);
+  });
+
+  it('lets a read-only query past the guard', async () => {
+    // Reaches DuckDB and fails there (pool not initialized in this suite),
+    // which proves the guard passed it rather than rejecting it.
+    const { body } = await postQuery(
+      "SELECT * FROM read_parquet('/nonexistent/x.parquet')"
+    );
+    expect(body.error ?? '').to.not.match(
+      /is not allowed|Only read-only queries|Table function/
+    );
+  });
+});

--- a/test/unit/buffer-isolation-invariant.test.ts
+++ b/test/unit/buffer-isolation-invariant.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Static invariant: no source code may let DuckDB open the live SQLite
+ * buffer. DuckDB's bundled SQLite cannot see node:sqlite's in-process POSIX
+ * locks; opening buffer.db truncates its -shm file under the writer's active
+ * mmap and kills the server with SIGBUS (see src/utils/buffer-staging.ts).
+ * Buffer rows must reach DuckDB only via staged TEMP tables.
+ *
+ * Every file under src/ is scanned for the patterns that reintroduce the
+ * crash. Comments are blanked first, using the TypeScript scanner rather than
+ * a hand-rolled lexer (a regex literal containing a quote desynchronises a
+ * naive one), so the hazard can still be documented in prose while SQL inside
+ * string literals stays visible to the scan.
+ */
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as ts from 'typescript';
+
+const SRC_DIR = path.join(__dirname, '..', '..', 'src');
+
+/**
+ * The guard names the forbidden functions in its own rejection messages and
+ * match patterns, so it would trip a scan meant for query code. It is exempt
+ * by name rather than by luck — today it passes only because none of those
+ * mentions happens to be followed by `(`, which a harmless reword would break.
+ */
+const EXEMPT_FILES = ['utils/sql-guard.ts'];
+
+const FORBIDDEN_PATTERNS: { name: string; pattern: RegExp }[] = [
+  { name: 'a sqlite_* table function call', pattern: /\bsqlite_\w+\s*\(/i },
+  { name: 'ATTACH ... TYPE SQLITE', pattern: /TYPE\s+SQLITE\b/i },
+  { name: 'getConnectionWithBuffer', pattern: /getConnectionWithBuffer/ },
+];
+
+/**
+ * Blank every comment in TypeScript source, preserving offsets and newlines
+ * so match positions still map to line numbers. String and template literals
+ * are left intact because the SQL this test looks for lives inside them.
+ *
+ * Input:  const sql = 'ATTACH x'; // ATTACH note
+ * Output: const sql = 'ATTACH x';
+ */
+function blankComments(source: string): string {
+  const chars = source.split('');
+  const sourceFile = ts.createSourceFile(
+    'scan.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    true
+  );
+
+  const blankRange = (pos: number, end: number): void => {
+    for (let i = pos; i < end && i < chars.length; i += 1) {
+      if (chars[i] !== '\n' && chars[i] !== '\r') {
+        chars[i] = ' ';
+      }
+    }
+  };
+
+  const visit = (node: ts.Node): void => {
+    for (const range of ts.getLeadingCommentRanges(
+      source,
+      node.getFullStart()
+    ) ?? []) {
+      blankRange(range.pos, range.end);
+    }
+    for (const range of ts.getTrailingCommentRanges(source, node.getEnd()) ??
+      []) {
+      blankRange(range.pos, range.end);
+    }
+    node.getChildren(sourceFile).forEach(visit);
+  };
+  visit(sourceFile);
+
+  return chars.join('');
+}
+
+function listSourceFiles(dir: string): string[] {
+  const isExempt = (entry: string): boolean =>
+    EXEMPT_FILES.some(exempt => entry.split(path.sep).join('/') === exempt);
+
+  return fs
+    .readdirSync(dir, { recursive: true, encoding: 'utf8' })
+    .filter(entry => entry.endsWith('.ts') && !isExempt(entry))
+    .map(entry => path.join(dir, entry));
+}
+
+function lineNumberAt(text: string, index: number): number {
+  return text.slice(0, index).split('\n').length;
+}
+
+describe('blankComments', () => {
+  it('removes line and block comments', () => {
+    expect(blankComments('const a = 1; // ATTACH note')).to.not.include(
+      'ATTACH'
+    );
+    expect(blankComments('/* ATTACH note */ const a = 1;')).to.not.include(
+      'ATTACH'
+    );
+  });
+
+  it('keeps string literal contents', () => {
+    expect(blankComments("const sql = 'ATTACH x';")).to.include('ATTACH x');
+  });
+
+  it('keeps template literal contents', () => {
+    expect(blankComments('const sql = `ATTACH ${p}`;')).to.include('ATTACH ');
+  });
+
+  it('does not desynchronise on a regex literal containing quotes', () => {
+    // A hand-rolled lexer treats the quote inside the regex as a string start
+    // and stops stripping comments from there on.
+    const source = 'const re = /[\'"]/g;\nconst b = 2; // ATTACH note';
+    expect(blankComments(source)).to.not.include('ATTACH');
+  });
+
+  it('preserves length and newlines', () => {
+    const source = 'const a = 1; // note\nconst b = 2;';
+    const blanked = blankComments(source);
+    expect(blanked).to.have.lengthOf(source.length);
+    expect(blanked.split('\n')).to.have.lengthOf(2);
+  });
+});
+
+describe('buffer isolation invariant', () => {
+  const files = listSourceFiles(SRC_DIR);
+
+  it('finds the source tree', () => {
+    expect(files.length).to.be.greaterThan(10);
+  });
+
+  for (const { name, pattern } of FORBIDDEN_PATTERNS) {
+    it(`no source file contains ${name}`, () => {
+      const violations: string[] = [];
+      for (const file of files) {
+        const scanned = blankComments(fs.readFileSync(file, 'utf8'));
+        const match = pattern.exec(scanned);
+        if (match) {
+          violations.push(
+            `${path.relative(SRC_DIR, file)}:${lineNumberAt(scanned, match.index)}`
+          );
+        }
+      }
+      expect(
+        violations,
+        `DuckDB must never open the live SQLite buffer (SIGBUS, see ` +
+          `buffer-staging.ts). Found ${name} in: ${violations.join(', ')}`
+      ).to.deep.equal([]);
+    });
+  }
+});

--- a/test/unit/claude-sql-guard.test.ts
+++ b/test/unit/claude-sql-guard.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Pins that model-generated SQL is guarded before it reaches DuckDB.
+ *
+ * This path has no opt-in flag: unlike /api/query, the analyzer runs whenever
+ * an analysis is requested, and the SQL comes from the model. A statement that
+ * opens the live write buffer with DuckDB's bundled SQLite would truncate
+ * buffer.db-shm under the writer's mmap and kill the server with SIGBUS (see
+ * src/utils/buffer-staging.ts).
+ *
+ * executeSQLQuery is private and takes no injectable seam, so it is reached
+ * through a cast. That is deliberate: the alternative is testing a copy of the
+ * logic, which would not catch the guard call being removed.
+ */
+import { expect } from 'chai';
+import * as fs from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  ClaudeAnalyzer,
+  ClaudeAnalyzerConfig,
+} from '../../src/claude-analyzer';
+
+type PrivateAnalyzer = {
+  executeSQLQuery(sql: string, purpose: string): Promise<unknown[]>;
+};
+
+/** Run executeSQLQuery and return the thrown message, or null if it resolved. */
+async function rejectionMessage(
+  analyzer: ClaudeAnalyzer,
+  sql: string
+): Promise<string | null> {
+  try {
+    await (analyzer as unknown as PrivateAnalyzer).executeSQLQuery(sql, 'test');
+    return null;
+  } catch (err) {
+    return (err as Error).message;
+  }
+}
+
+describe('ClaudeAnalyzer SQL guard', () => {
+  let analyzer: ClaudeAnalyzer;
+  let dataDir: string;
+
+  beforeEach(async () => {
+    // The Anthropic client is constructed but never called on this path; the
+    // data directory is only needed by the vessel context manager.
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-guard-'));
+    analyzer = new ClaudeAnalyzer(
+      { apiKey: 'test-key-not-used' } as ClaudeAnalyzerConfig,
+      undefined,
+      dataDir
+    );
+  });
+
+  afterEach(async () => {
+    await fs.remove(dataDir);
+  });
+
+  it('rejects ATTACH of a SQLite database', async () => {
+    const message = await rejectionMessage(
+      analyzer,
+      "ATTACH '/d/buffer.db' AS b (TYPE SQLITE)"
+    );
+    expect(message).to.match(/^Query rejected for security:/);
+    expect(message).to.match(/'ATTACH' is not allowed/);
+  });
+
+  it('rejects a sqlite_scan table function inside a SELECT', async () => {
+    const message = await rejectionMessage(
+      analyzer,
+      "SELECT * FROM sqlite_scan('/d/buffer.db', 't')"
+    );
+    expect(message).to.match(/Table function/);
+  });
+
+  it('rejects a quoted-identifier sqlite_scan', async () => {
+    const message = await rejectionMessage(
+      analyzer,
+      `SELECT v FROM "sqlite_scan"('/d/buffer.db','t')`
+    );
+    expect(message).to.match(/Table function/);
+  });
+
+  it('rejects a statement chained after a benign SELECT', async () => {
+    const message = await rejectionMessage(
+      analyzer,
+      'SELECT 1; INSTALL sqlite'
+    );
+    expect(message).to.match(/'INSTALL' is not allowed/);
+  });
+
+  it('does not reject a legitimate read-only query at the guard', async () => {
+    // Without a DuckDB pool this still fails, but on the pool rather than the
+    // guard — which is what distinguishes a working guard from a no-op one.
+    const message = await rejectionMessage(
+      analyzer,
+      "SELECT signalk_timestamp, value FROM read_parquet('/d/*.parquet')"
+    );
+    expect(message ?? '').to.not.match(/rejected for security/);
+  });
+});

--- a/test/unit/utils/sql-guard.test.ts
+++ b/test/unit/utils/sql-guard.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Unit tests for the SQL guard protecting the two paths that execute
+ * externally-supplied SQL (raw /api/query and Claude-generated analysis
+ * queries). The guard exists because DuckDB's bundled SQLite opening the live
+ * write buffer truncates buffer.db-shm under the writer's mmap and kills the
+ * server with SIGBUS, so every statement must be read-only and no
+ * database-opening table function may appear.
+ *
+ * The bypass cases below were all confirmed to execute on DuckDB 1.5.3 before
+ * the rule that rejects them was added.
+ */
+import { expect } from 'chai';
+import {
+  maskSqlLiteralsAndComments,
+  findUnsafeSqlReason,
+} from '../../../src/utils/sql-guard';
+
+describe('maskSqlLiteralsAndComments', () => {
+  it('preserves length so offsets stay aligned', () => {
+    const sql = "SELECT 'abc' FROM t -- note";
+    expect(maskSqlLiteralsAndComments(sql)).to.have.lengthOf(sql.length);
+  });
+
+  it('masks single-quoted literals', () => {
+    expect(
+      maskSqlLiteralsAndComments("SELECT * FROM t WHERE p = 'engine.load'")
+    ).to.not.include('load');
+  });
+
+  it('handles doubled-quote escapes inside literals', () => {
+    const masked = maskSqlLiteralsAndComments(
+      "SELECT 'it''s a load' AS note FROM t"
+    );
+    expect(masked).to.not.include('load');
+    expect(masked).to.include('AS note');
+  });
+
+  it('masks dollar-quoted strings', () => {
+    const masked = maskSqlLiteralsAndComments('SELECT $$a load$$ AS x');
+    expect(masked).to.not.include('load');
+    expect(masked).to.include('AS x');
+  });
+
+  it('masks tagged dollar-quoted strings', () => {
+    expect(
+      maskSqlLiteralsAndComments('SELECT $tag$ attach $tag$ AS x')
+    ).to.not.include('attach');
+  });
+
+  it('masks an apostrophe inside a dollar-quoted string', () => {
+    // The apostrophe in don't must not start a literal: doing so shifts every
+    // later quote boundary and hides the following statement.
+    const masked = maskSqlLiteralsAndComments(
+      "SELECT $$don't$$ AS a; ATTACH '/d/buffer.db' AS b"
+    );
+    expect(masked).to.include('ATTACH');
+  });
+
+  it('masks quoted identifiers', () => {
+    expect(maskSqlLiteralsAndComments('SELECT "load" FROM t')).to.not.include(
+      'load'
+    );
+  });
+
+  it('masks line and block comments', () => {
+    expect(
+      maskSqlLiteralsAndComments('SELECT 1 -- attach the buffer\nFROM t')
+    ).to.not.include('attach');
+    expect(
+      maskSqlLiteralsAndComments('SELECT /* load bearing */ 1')
+    ).to.not.include('load');
+  });
+
+  it('keeps newlines for line alignment', () => {
+    expect(maskSqlLiteralsAndComments('SELECT 1 -- c\nFROM t')).to.include(
+      '\nFROM t'
+    );
+  });
+
+  describe('unterminated constructs blank the rest of the input', () => {
+    // Each of these is a DuckDB parse error ("unterminated quoted string",
+    // "unterminated /* comment", and the equivalents for quoted identifiers
+    // and dollar-quoted strings), so blanking to end cannot hide an
+    // executable statement.
+    const cases: [string, string][] = [
+      ['single quote', "SELECT 'oops; LOAD sqlite"],
+      ['block comment', 'SELECT 1 /* oops; LOAD sqlite'],
+      ['quoted identifier', 'SELECT "oops; LOAD sqlite'],
+      ['dollar quote', 'SELECT $tag$ oops; LOAD sqlite'],
+    ];
+
+    for (const [label, sql] of cases) {
+      it(`blanks after an unterminated ${label}`, () => {
+        expect(maskSqlLiteralsAndComments(sql)).to.not.include('LOAD');
+      });
+    }
+  });
+});
+
+describe('findUnsafeSqlReason', () => {
+  describe('allows legitimate read-only queries', () => {
+    it('allows a plain SELECT over parquet', () => {
+      expect(
+        findUnsafeSqlReason(
+          "SELECT signalk_timestamp, value FROM read_parquet('/d/*.parquet') " +
+            "WHERE context = 'vessels.self' ORDER BY signalk_timestamp"
+        )
+      ).to.equal(null);
+    });
+
+    it('allows a WITH/CTE query', () => {
+      expect(
+        findUnsafeSqlReason(
+          "WITH b AS (SELECT * FROM read_parquet('/d/*.parquet')) " +
+            'SELECT count(*) FROM b'
+        )
+      ).to.equal(null);
+    });
+
+    it('allows a trailing semicolon and surrounding whitespace', () => {
+      expect(findUnsafeSqlReason('  SELECT 1;  ')).to.equal(null);
+    });
+
+    it('allows lowercase select', () => {
+      expect(findUnsafeSqlReason('select 1')).to.equal(null);
+    });
+
+    it('allows a leading comment before the statement', () => {
+      expect(findUnsafeSqlReason('-- daily average\nSELECT 1')).to.equal(null);
+    });
+
+    it('allows identifiers that contain blocked keywords', () => {
+      expect(
+        findUnsafeSqlReason(
+          'SELECT payload, engine_load, created_at, updated_at FROM t'
+        )
+      ).to.equal(null);
+    });
+
+    it('allows a bare alias named load', () => {
+      // A model analyzing propulsion.main.load naturally picks this alias.
+      expect(findUnsafeSqlReason('SELECT AVG(value) AS load FROM t')).to.equal(
+        null
+      );
+    });
+
+    it('allows file paths containing blocked words inside literals', () => {
+      expect(
+        findUnsafeSqlReason(
+          "SELECT * FROM read_parquet('/d/path=propulsion.main.load/*.parquet')"
+        )
+      ).to.equal(null);
+    });
+
+    it('allows spatial function queries', () => {
+      expect(
+        findUnsafeSqlReason(
+          'SELECT ST_Distance_Sphere(ST_Point(lon, lat), ST_Point(0, 0)) FROM t'
+        )
+      ).to.equal(null);
+    });
+  });
+
+  describe('allows read-only DuckDB syntax beyond plain SELECT', () => {
+    // All verified to execute on DuckDB 1.5.3. These are idiomatic in a raw
+    // SQL console, so rejecting them would be an unannounced regression.
+    const readOnly: [string, string][] = [
+      ['FROM-first', "FROM read_parquet('/d/*.parquet') SELECT *"],
+      ['parenthesised union', '(SELECT 1) UNION (SELECT 2)'],
+      ['DESCRIBE', 'DESCRIBE SELECT 1'],
+      ['SUMMARIZE', 'SUMMARIZE SELECT 1'],
+      ['EXPLAIN', 'EXPLAIN SELECT 1'],
+      ['VALUES', 'VALUES (1), (2)'],
+      ['PIVOT', 'PIVOT (SELECT 1 AS a, 2 AS b) ON a USING sum(b)'],
+      ['SHOW', 'SHOW TABLES'],
+    ];
+
+    for (const [label, sql] of readOnly) {
+      it(`allows ${label}`, () => {
+        expect(findUnsafeSqlReason(sql)).to.equal(null);
+      });
+    }
+  });
+
+  describe('rejects statements that can reach the live buffer', () => {
+    it('rejects ATTACH of a SQLite file', () => {
+      expect(
+        findUnsafeSqlReason("ATTACH '/d/buffer.db' AS b (TYPE SQLITE)")
+      ).to.match(/'ATTACH' is not allowed/);
+    });
+
+    it('rejects a statement chained after a benign SELECT', () => {
+      expect(
+        findUnsafeSqlReason("SELECT 1; ATTACH '/d/buffer.db' AS b")
+      ).to.match(/'ATTACH' is not allowed/);
+    });
+
+    it('rejects re-enabling extension autoloading', () => {
+      // This would undo the engine-level lockdown in duckdb-pool.
+      expect(
+        findUnsafeSqlReason(
+          'SELECT 1; SET GLOBAL autoload_known_extensions = true'
+        )
+      ).to.match(/'SET' is not allowed/);
+    });
+
+    it('rejects INSTALL and FORCE INSTALL', () => {
+      expect(findUnsafeSqlReason('INSTALL sqlite')).to.match(
+        /'INSTALL' is not allowed/
+      );
+      expect(findUnsafeSqlReason('FORCE INSTALL sqlite')).to.match(
+        /'FORCE' is not allowed/
+      );
+    });
+
+    it('rejects LOAD and PRAGMA', () => {
+      expect(findUnsafeSqlReason('LOAD sqlite')).to.match(
+        /'LOAD' is not allowed/
+      );
+      expect(findUnsafeSqlReason('PRAGMA database_list')).to.match(
+        /'PRAGMA' is not allowed/
+      );
+    });
+
+    it('rejects sqlite_scan, sqlite_attach and sqlite_query', () => {
+      for (const fn of ['sqlite_scan', 'sqlite_attach', 'sqlite_query']) {
+        expect(
+          findUnsafeSqlReason(`SELECT * FROM ${fn}('/d/buffer.db', 't')`),
+          fn
+        ).to.match(/Table function/);
+      }
+    });
+
+    it('rejects a quoted-identifier sqlite function call', () => {
+      // DuckDB resolves "sqlite_scan"(...) exactly like the bare form; this
+      // returned live buffer rows when the name check ran over SQL whose
+      // quoted identifiers had already been masked.
+      expect(
+        findUnsafeSqlReason(`SELECT v FROM "sqlite_scan"('/d/buffer.db','t')`)
+      ).to.match(/Table function/);
+    });
+
+    it('rejects nesting a SQLite scan inside query()', () => {
+      // The nested SQL is a string literal, so the statement whitelist cannot
+      // see into it; query() itself has to be rejected.
+      expect(
+        findUnsafeSqlReason(
+          `SELECT v FROM query('SELECT v FROM sqlite_scan(''/d/buffer.db'',''t'')')`
+        )
+      ).to.match(/Table function 'query'/);
+    });
+
+    it('rejects query_table', () => {
+      expect(findUnsafeSqlReason("SELECT * FROM query_table('t')")).to.match(
+        /Table function/
+      );
+    });
+
+    it('rejects CALL of a sqlite function', () => {
+      expect(
+        findUnsafeSqlReason("CALL sqlite_attach('/d/buffer.db')")
+      ).to.match(/'CALL' is not allowed/);
+    });
+
+    it('rejects sqlite functions regardless of case and spacing', () => {
+      expect(
+        findUnsafeSqlReason("SELECT * FROM SQLITE_SCAN ('/d/buffer.db', 't')")
+      ).to.match(/Table function/);
+    });
+
+    it('rejects a statement hidden behind a dollar-quoted apostrophe', () => {
+      expect(
+        findUnsafeSqlReason(
+          "SELECT $$don't$$ AS a; ATTACH '/d/buffer.db' AS b (TYPE SQLITE)"
+        )
+      ).to.match(/'ATTACH' is not allowed/);
+    });
+  });
+
+  describe('rejects raw file readers', () => {
+    for (const fn of ['read_text', 'read_blob', 'glob']) {
+      it(`rejects ${fn}`, () => {
+        expect(
+          findUnsafeSqlReason(`SELECT * FROM ${fn}('/etc/passwd')`)
+        ).to.match(/Table function/);
+      });
+    }
+
+    it('rejects duckdb_secrets', () => {
+      expect(findUnsafeSqlReason('SELECT * FROM duckdb_secrets()')).to.match(
+        /Table function/
+      );
+    });
+
+    it('still allows read_parquet and read_csv', () => {
+      expect(
+        findUnsafeSqlReason("SELECT * FROM read_parquet('/d/x.parquet')")
+      ).to.equal(null);
+      expect(
+        findUnsafeSqlReason("SELECT * FROM read_csv('/d/x.csv')")
+      ).to.equal(null);
+    });
+  });
+
+  describe('rejects filesystem writes', () => {
+    it('rejects COPY ... TO', () => {
+      expect(findUnsafeSqlReason("COPY (SELECT 1) TO '/d/buffer.db'")).to.match(
+        /'COPY' is not allowed/
+      );
+    });
+
+    it('rejects EXPORT DATABASE', () => {
+      expect(
+        findUnsafeSqlReason("SELECT 1; EXPORT DATABASE '/d/out'")
+      ).to.match(/'EXPORT' is not allowed/);
+    });
+  });
+
+  describe('rejects data modification', () => {
+    for (const sql of [
+      'DROP TABLE t',
+      'DELETE FROM t',
+      'UPDATE t SET a = 1',
+      'INSERT INTO t VALUES (1)',
+      'CREATE TABLE t (a INT)',
+      'ALTER TABLE t ADD COLUMN b INT',
+      'TRUNCATE t',
+    ]) {
+      it(`rejects ${sql.split(' ')[0]}`, () => {
+        expect(findUnsafeSqlReason(sql)).to.match(/Only read-only queries/);
+      });
+    }
+
+    it('rejects a WITH-prefixed INSERT', () => {
+      // This parses and runs on DuckDB and starts with an allowed keyword, so
+      // only the anywhere-scan for data-modifying keywords catches it.
+      expect(
+        findUnsafeSqlReason(
+          'WITH x AS (SELECT 3 AS a) INSERT INTO t SELECT a FROM x'
+        )
+      ).to.match(/Data-modifying keyword 'INSERT'/);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('rejects empty input', () => {
+      expect(findUnsafeSqlReason('')).to.equal('Query is empty.');
+    });
+
+    it('rejects whitespace-only input', () => {
+      expect(findUnsafeSqlReason('   \n  ')).to.equal('Query is empty.');
+    });
+
+    it('rejects a comment-only query', () => {
+      expect(findUnsafeSqlReason('-- nothing here')).to.equal(
+        'Query is empty.'
+      );
+    });
+
+    it('ignores empty statements from repeated semicolons', () => {
+      expect(findUnsafeSqlReason('SELECT 1;; ;')).to.equal(null);
+    });
+
+    it('names the offending statement so callers can correct it', () => {
+      expect(findUnsafeSqlReason('VACUUM')).to.include("got 'VACUUM'");
+    });
+  });
+});

--- a/tests/repro-shm-truncation.js
+++ b/tests/repro-shm-truncation.js
@@ -1,0 +1,130 @@
+/**
+ * Reproduces the buffer.db-shm truncation SIGBUS caused by two SQLite
+ * libraries sharing one WAL database in the same process.
+ *
+ * Mechanism: POSIX advisory locks never conflict within a single process, and
+ * each SQLite library instance only coordinates its own connections. When
+ * DuckDB's bundled SQLite (sqlite extension) attaches a database that
+ * node:sqlite is writing, its "am I the first shm user" probe always
+ * succeeds, so it truncates the -shm file to zero and rebuilds it sized to
+ * the current WAL. The node:sqlite writer keeps its stale mmap of the upper
+ * shm regions; the next write burst that grows the WAL past ~4062 frames
+ * touches an unbacked page and dies with SIGBUS (exit code 135).
+ *
+ * Run manually on Linux (e.g. inside the SignalK test container); the shm
+ * behavior is platform-specific and the crash is the expected outcome:
+ *
+ *   node tests/repro-shm-truncation.js
+ *
+ * First run needs network access (DuckDB downloads the sqlite extension).
+ *
+ * Expected output ends like:
+ *   phase 3: shm after DuckDB attach: 32768 bytes (was 65536) TRUNCATED
+ *   phase 4: writing until the stale region-1 mapping is touched...
+ *   Bus error (core dumped)   <- exit code 135
+ *
+ * If the process survives phase 4 and prints "did not reproduce", the
+ * platform or library versions do not exhibit the bug.
+ */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const REGION_SIZE = 32768; // SQLite WAL-index shm region size
+const FILLER = 'x'.repeat(1024);
+
+function shmSize(dbPath) {
+  try {
+    return fs.statSync(dbPath + '-shm').size;
+  } catch {
+    return 0;
+  }
+}
+
+async function main() {
+  if (process.platform !== 'linux') {
+    console.log(
+      `This repro needs Linux POSIX advisory-lock and mmap semantics ` +
+        `(current platform: ${process.platform}). Run it inside the SignalK ` +
+        `test container.`
+    );
+    return;
+  }
+
+  const { DatabaseSync } = require('node:sqlite');
+  const { DuckDBInstance } = require('@duckdb/node-api');
+
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shm-repro-'));
+  const dbPath = path.join(dir, 'buffer.db');
+  console.log(`database: ${dbPath}`);
+
+  // Phase 1: live writer with a WAL-index spanning two shm regions. With
+  // autocheckpoint off, every autocommit insert appends frames; the shm file
+  // grows to 64KB exactly when the writer maps region 1 (frame ~4062), which
+  // is the mapping the truncation later invalidates.
+  const writer = new DatabaseSync(dbPath);
+  writer.exec('PRAGMA journal_mode = WAL');
+  writer.exec('PRAGMA wal_autocheckpoint = 0');
+  writer.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, payload TEXT)');
+  const insert = writer.prepare('INSERT INTO t (payload) VALUES (?)');
+
+  let rows = 0;
+  while (shmSize(dbPath) < 2 * REGION_SIZE) {
+    insert.run(FILLER);
+    rows += 1;
+    if (rows > 200000) {
+      throw new Error('WAL never reached region 1; aborting');
+    }
+  }
+  console.log(
+    `phase 1: ${rows} rows, shm = ${shmSize(dbPath)} bytes (writer has region 1 mapped)`
+  );
+
+  // Phase 2: checkpoint like the export cycle does. The WAL shrinks to zero
+  // but the shm keeps its high-water size; the writer keeps its mappings.
+  writer.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+  const shmBefore = shmSize(dbPath);
+  console.log(
+    `phase 2: after wal_checkpoint(TRUNCATE), shm = ${shmBefore} bytes`
+  );
+
+  // Phase 3: DuckDB's bundled SQLite attaches the live database read-only,
+  // wins the dead-man-switch probe (same process, foreign lock table),
+  // truncates the shm to zero, and rebuilds only region 0 for the empty WAL.
+  const instance = await DuckDBInstance.create(':memory:');
+  const conn = await instance.connect();
+  await conn.runAndReadAll('INSTALL sqlite;');
+  await conn.runAndReadAll('LOAD sqlite;');
+  await conn.runAndReadAll(
+    `ATTACH '${dbPath}' AS repro (TYPE SQLITE, READ_ONLY);`
+  );
+  const reader = await conn.runAndReadAll('SELECT count(*) AS n FROM repro.t;');
+  console.log(`phase 3: DuckDB sees ${reader.getRowObjects()[0].n} rows`);
+  conn.disconnectSync();
+
+  const shmAfter = shmSize(dbPath);
+  console.log(
+    `phase 3: shm after DuckDB attach: ${shmAfter} bytes (was ${shmBefore})` +
+      (shmAfter < shmBefore ? ' TRUNCATED' : '')
+  );
+
+  // Phase 4: the export-hour write burst. Frames restart from 1 after the
+  // checkpoint, so the writer fills region 0 again and then touches its
+  // stale region-1 mapping, which the truncated file no longer backs.
+  console.log(
+    'phase 4: writing until the stale region-1 mapping is touched...'
+  );
+  for (let i = 0; i < 6000; i += 1) {
+    insert.run(FILLER);
+  }
+
+  console.log(
+    `did not reproduce: writer survived phase 4 (shm = ${shmSize(dbPath)} bytes)`
+  );
+  writer.close();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Problem

DuckDB's bundled SQLite cannot see node:sqlite's in-process POSIX advisory locks: within a single process a second `fcntl` lock request never conflicts with the first, and SQLite's in-process lock table only covers connections of the same library instance. So when DuckDB opens the live `buffer.db`, its "am I the first shm user" probe always succeeds, it concludes the WAL index is stale, truncates `buffer.db-shm` to zero and rebuilds it sized to the current WAL.

If the writer still has an upper shm region mapped, that mapping is now unbacked. The next write burst that grows the WAL past the first region touches a page with no file behind it and the server dies with SIGBUS (exit 135). In production this detonated at the daily export hour, after `wal_checkpoint(TRUNCATE)` left the WAL near-empty while the shm was still multi-region.

The ATTACH-based federation that triggered this was already replaced by TEMP-table staging, but two paths could still reach the same code with arbitrary SQL: the raw `POST /api/query` endpoint (opt-in), and `ClaudeAnalyzer.executeSQLQuery`, which runs model-generated SQL and is **not** gated by `enableRawSql`.

## Approach

Both paths now require every statement to be read-only, and reject the table functions that open a database or a file from inside an otherwise valid SELECT.

A keyword blocklist was tried first and lost. All of these were confirmed to execute on DuckDB 1.5.3:

- `SELECT 1; SET GLOBAL autoload_known_extensions=true; SELECT * FROM sqlite_attach(...)` — the engine lockdown is a runtime-mutable setting, and `sqlite_attach` has no word boundary before `attach`.
- `SELECT $$don't$$ AS a; ATTACH '...' (TYPE SQLITE)` — an apostrophe inside a dollar-quoted string desynchronised literal stripping and hid the next statement.
- `EXPORT DATABASE '/path'` — keyword-free, writes files, unaffected by any extension setting.

Review then found the same class of hole in the replacement, and it is the one worth highlighting: because the function-name check ran over SQL whose quoted identifiers had already been masked, both of these passed the guard and returned live rows out of a SQLite file.

```sql
SELECT v FROM "sqlite_scan"('buffer.db','t')
SELECT v FROM query('SELECT v FROM sqlite_scan(''buffer.db'',''t'')')
```

The name check now runs over SQL with quoted identifiers still visible, and `query`/`query_table` are rejected because they execute a nested SQL string the statement rule cannot see into.

The whitelist deliberately accepts the read-only syntax a SQL console needs — FROM-first queries, `DESCRIBE`, `SUMMARIZE`, `EXPLAIN`, `VALUES`, `PIVOT`, `SHOW`, and a parenthesised leading subquery — so it does not silently narrow what the endpoint accepted before.

### Engine lockdown

`DuckDBPool` removes a cached `sqlite_scanner` from its extension directory, disables extension autoinstall/autoload, and locks the configuration. The removal matters most: **an already-cached extension loads on `ATTACH ... (TYPE SQLITE)` regardless of the autoload setting**, and every installation that ran the old federation code has one cached — i.e. exactly the affected population.

These measures do not stop an explicit `INSTALL sqlite`, which only the statement whitelist rejects. The two layers are therefore complementary rather than redundant, and the comments now say that instead of each justifying its own leniency by pointing at the other. Settings are applied individually and read back, and `isSqliteLockedDown()` reports the outcome so a degraded state is visible rather than assumed. Hardening failures warn instead of aborting startup, matching the existing best-effort treatment of the spatial extension.

### Also on the raw SQL path

- The guard validates the string that actually executes, after path substitution, so the guarded and executed SQL cannot diverge.
- Path substitution uses a replacer function, so `$&` in a user-supplied path cannot splice unvalidated text into the query.
- Results are capped before being materialised into the Node heap, which DuckDB's own memory limit does not bound.
- Rejections are logged server-side on both paths.

## Verification

Verified against DuckDB 1.5.3 in a fresh process: 22 dangerous forms rejected (including both quoted-identifier and `query()` bypasses, `CALL sqlite_attach`, `FORCE INSTALL`, `EXPORT DATABASE`, `COPY TO`, the dollar-quote trick, and the raw file readers) and 14 legitimate forms still allowed (including `AS load` aliases, `propulsion.main.load` paths, `created_at` identifiers, spatial, `time_bucket`, FROM-first and `DESCRIBE`).

`initialize()` removes the cached extension; a subsequent `ATTACH ... (TYPE SQLITE)` then fails with "Extension ... not found" and re-enabling autoinstall fails with "the configuration has been locked". `INSTALL`/`LOAD httpfs` and `CREATE SECRET` still succeed after the lock, so the S3 path is unaffected.

`npm run typecheck`, `npm test` (616 passing), `npm run lint` (0 errors) and `npm run format:check` are clean.

## Tests

- `test/unit/utils/sql-guard.test.ts` — guard behaviour including every confirmed bypass and the false-positive cases.
- `test/integration/raw-sql-guard-http.test.ts` and `test/unit/claude-sql-guard.test.ts` — pin the wiring at both call sites. Verified by mutation: disabling either guard call fails the suite, which was not previously true.
- `test/integration/duckdb-sqlite-lockdown.test.ts` — extension removal, settings read-back, locked configuration, and that `ATTACH ... TYPE SQLITE` fails afterwards. This path never executed in CI before.
- `test/unit/buffer-isolation-invariant.test.ts` — static scan failing if any source file reintroduces `ATTACH ... TYPE SQLITE`, a `sqlite_*` call, or `getConnectionWithBuffer`. Uses the TypeScript scanner to blank comments, since a hand-rolled lexer desynchronises on regex literals containing quotes.
- `tests/repro-shm-truncation.js` — manual Linux script reproducing the shm truncation and the SIGBUS.
- `sql-guard.ts` added to the Stryker mutation list.

## Notes

- Not fixed here: with raw SQL enabled, `read_parquet`/`read_csv` can still read any path the process can reach. That is inherent to an endpoint whose purpose is running SQL over local files, it predates this change, and the guard's comments no longer claim otherwise. `read_text`/`read_blob`/`glob`/`duckdb_secrets` are now rejected since they have no legitimate use here.
- The un-exported backlog that let the shm span two regions in the first place is a separate export-starvation issue.